### PR TITLE
fix error when running on a new thread

### DIFF
--- a/TikTokLive/client/base.py
+++ b/TikTokLive/client/base.py
@@ -70,9 +70,9 @@ class BaseClient(AsyncIOEventEmitter):
             self.loop: AbstractEventLoop = loop
         else:
             try:
-                self.loop: AbstractEventLoop = asyncio.get_event_loop()
-            except RuntimeError:
                 self.loop: AbstractEventLoop = asyncio.get_running_loop()
+            except RuntimeError:
+                self.loop: AbstractEventLoop = asyncio.new_event_loop()
 
         # Private Attributes
         self.__unique_id: str = validate_and_normalize_unique_id(unique_id)


### PR DESCRIPTION
closes #63 

I tested locally on python 3.7 environment that this code works in both the main thread and a new thread. 

test code for a new thread:

```py
import threading
import time
import asyncio
from TikTokLive import TikTokLiveClient

def start_tiktok():
    client = TikTokLiveClient(unique_id='@xxx')

    @client.on("comment")
    async def on_connect(event):
      print(event.comment)

    client.run()

thread = threading.Thread(target=start_tiktok)
thread.daemon = True
thread.start()

time.sleep(10)
```