### PR TITLE
fix(download): add flv live stream

### DIFF
--- a/TikTokLive/client/base.py
+++ b/TikTokLive/client/base.py
@@ -563,6 +563,8 @@ class BaseClient(AsyncIOEventEmitter):
 
         # Set the URL based on selected quality
         url_param: str = url['data'][quality.value]['main']['hls']
+        if len(url_param.strip()) == 0:
+            url_param: str = url['data'][quality.value]['main']['flv']
 
         # Function Running
         def spool():


### PR DESCRIPTION
Some live streams do not have hls addresses, you can use flv addresses to download live streams
