### PR TITLE
Library re \d depreciation

### DIFF
--- a/TikTokLive/proto/proto_utils.py
+++ b/TikTokLive/proto/proto_utils.py
@@ -81,5 +81,5 @@ def badge_match(badge: BadgeStruct, p: re.Pattern) -> Optional[re.Match]:
 SUBSCRIBER_BADGE_PATTERN: re.Pattern = re.compile("/sub_")
 MODERATOR_BADGE_PATTERN: re.Pattern = re.compile("moderator", flags=re.IGNORECASE)
 TOP_GIFTER_BADGE_PATTERN: re.Pattern = re.compile("/new_top_gifter", flags=re.IGNORECASE)
-MEMBER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("fans_badge_icon_lv(\d+)_v")
-GIFTER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("grade_badge_icon_lite_lv(\d+)_v")
+MEMBER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("fans_badge_icon_lv(\\d+)_v")
+GIFTER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("grade_badge_icon_lite_lv(\\d+)_v")


### PR DESCRIPTION
This fixes the depreciation of \d in re.
`python3.12/site-packages/TikTokLive/proto/proto_utils.py:84: SyntaxWarning: invalid escape sequence '\d' MEMBER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("fans_badge_icon_lv(\d+)_v")`

`python3.12/site-packages/TikTokLive/proto/proto_utils.py:85: SyntaxWarning: invalid escape sequence '\d' GIFTER_LEVEL_BADGE_PATTERN: re.Pattern = re.compile("grade_badge_icon_lite_lv(\d+)_v")`
Reference: https://stackoverflow.com/questions/50504500/deprecationwarning-invalid-escape-sequence-what-to-use-instead-of-d