### PR TITLE
bugfix: await client disconnect

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -405,7 +405,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
             if event.action == ControlAction.STREAM_ENDED:
 
                 # If the stream is over, disconnect the client
-                self.disconnect()
+                await self.disconnect()
 
                 return LiveEndEvent().parse(response.payload)
             elif event.action == ControlAction.STREAM_PAUSED:


### PR DESCRIPTION
/venv_debug/lib/python3.12/site-packages/TikTokLive/client/client.py:408: RuntimeWarning: coroutine 'TikTokLiveClient.disconnect' was never awaited
  self.disconnect()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
