### PR TITLE
feat(client): added suspended protobuf and event handle

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -402,7 +402,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         # LiveEndEvent, LivePauseEvent, LiveUnpauseEvent
         if isinstance(event, ControlEvent):
-            if event.action == ControlAction.STREAM_ENDED:
+            if event.action in {ControlAction.STREAM_ENDED, ControlAction.STREAM_SUSPENDED}:
 
                 # If the stream is over, disconnect the client
                 await self.disconnect()

--- a/scripts/proto/src/enums.proto
+++ b/scripts/proto/src/enums.proto
@@ -153,6 +153,7 @@ enum ControlAction {
   STREAM_PAUSED = 1; // Stream Paused by Host
   STREAM_UNPAUSED = 2;
   STREAM_ENDED = 3; // Stream Ended by Host
+  STREAM_SUSPENDED = 4; // Stream Ended by TikTok
 }
 
 enum LinkLayerMessageType


### PR DESCRIPTION
See: https://github.com/zerodytrash/TikTok-Live-Connector
Source: https://github.com/zerodytrash/TikTok-Live-Connector/blob/3277f0707dd4702650e682eed0bcd06b936de7e3/src/index.js#L531

```tiktokLiveConnection.on('streamEnd', (actionId) => {
    if (actionId === 3) {
        console.log('Stream ended by user');
    }
    if (actionId === 4) {
        console.log('Stream ended by platform moderator (ban)');
    }
})```