### PR TITLE
hotfix(client): flv codec problem

### DIFF
--- a/TikTokLive/client/web/web_settings.py
+++ b/TikTokLive/client/web/web_settings.py
@@ -38,7 +38,6 @@ DEFAULT_CLIENT_PARAMS: Dict[str, Union[int, str]] = {
 
     # New Data
     "data_collection_enabled": "true",
-    "device_type": "web_h265",
     "os": Device["os"],
     "priority_region": Location["country"],
     "region": Location["country"],


### PR DESCRIPTION
Fixes
[flv @ 000002498ba1fac0] Video codec (c) is not implemented. 
