### PR TITLE
- Fix ws_proxy authentication

### DIFF
--- a/TikTokLive/client/ws/ws_client.py
+++ b/TikTokLive/client/ws/ws_client.py
@@ -144,8 +144,8 @@ class WebcastWSClient:
         parsed: list = list(parsed)
 
         # Add auth back
-        parsed[3] = self._ws_proxy.url.username
-        parsed[4] = self._ws_proxy.url.password
+        parsed[3] = self._ws_proxy.auth[0]
+        parsed[4] = self._ws_proxy.auth[1]
 
         return websockets_proxy.Proxy(*parsed)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
             "httpx>=0.25.0",
             "pyee>=9.0.4",
             "ffmpy>=0.3.0",
-            "websockets_proxy==0.1.2",
+            "websockets_proxy==0.1.3",
 
             # Downgrade to b1. This is necessary because to_dict breaks for ShareEvent in 2.0.0b2 due to 'Common' not being defined. No clue why.
             "betterproto==2.0.0b1",


### PR DESCRIPTION
- Change websockets_proxy to version 0.1.3 to fix this: https://github.com/racinette/websockets_proxy/commit/749581e4dc389cbcf78a8a3841b0060983f712bb