### PR TITLE
Remove usage of httpx removed proxies keyword, now uses proxy argument. keyword…

### DIFF
--- a/TikTokLive/client/web/web_base.py
+++ b/TikTokLive/client/web/web_base.py
@@ -66,7 +66,7 @@ class TikTokHTTPClient:
         }
 
         return AsyncClient(
-            proxies=proxy,
+            proxy=proxy,
             cookies=self.cookies,
             **httpx_kwargs
         )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ manifest: dict = {
     "name": "TikTokLive",
     "license": "MIT",
     "author": "Isaac Kogan",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "email": "info@isaackogan.com"
 }
 
@@ -29,7 +29,7 @@ if __name__ == '__main__':
         download_url=f"https://github.com/isaackogan/TikTokLive/releases/tag/v{manifest['version']}",
         keywords=["tiktok", "tiktok live", "python3", "api", "unofficial"],
         install_requires=[
-            "httpx>=0.25.0",
+            "httpx>=0.26.0",
             "pyee>=9.0.4",
             "ffmpy>=0.3.0",
             "websockets_proxy==0.1.2",


### PR DESCRIPTION
Httpx proxies argument was removed in httpx 0.28.0 causing the following errors in new pip installs of TikTokLive:
```
File "<removed>\.env\Lib\site-packages\TikTokLive\client\web\web_base.py", line 68, in _create_httpx_client
    return AsyncClient(
           ^^^^^^^^^^^^
TypeError: AsyncClient.__init__() got an unexpected keyword argument 'proxies'
```
Documented here: https://github.com/encode/httpx/blob/master/CHANGELOG.md#0280-28th-november-2024

The workaround was to downgrade httx, but this resolves that.

I also updated the min requirements to httx to 0.26.0 because that was the first release proxy keyword was created and proxies was deprecated.
