### PR TITLE
handle error from event loop on disconnecting

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -225,7 +225,10 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         # Wait for the event loop task to finish
         if self._event_loop_task is not None:
-            await self._event_loop_task
+            try:
+                await self._event_loop_task
+            except Exception:
+                self._logger.debug("an exception in event loop is ignored", exc_info=True)
             self._event_loop_task = None
 
         # If recording, stop it


### PR DESCRIPTION
# What
awaiting _event_loop_task may raise exception from WebcastIterator and it results in the following processes not to be executed.

# How
just catch and ignore exceptions on disconnecting