### PR TITLE
refact(fetch_video_data) outputs construction to improve argument merging order

### DIFF
--- a/TikTokLive/client/web/routes/fetch_video_data.py
+++ b/TikTokLive/client/web/routes/fetch_video_data.py
@@ -134,11 +134,11 @@ class FetchVideoDataRoute(ClientRoute):
         self._ffmpeg = FFmpeg(
             inputs={**{record_url: None}, **kwargs.pop('inputs', dict())},
             outputs={
+                **kwargs.pop('outputs', dict()),
                 **{
                     str(output_fp): record_time,
                     output_format or record_format.value: "-f"
                 },
-                **kwargs.pop('outputs', dict())
             },
             global_options=(
                 list(


### PR DESCRIPTION
#### Now we can use segment in recording

```python
    # Start a recording
    client.web.fetch_video_data.start(
        output_fp=f"{event.unique_id}-%03d.mp4",
        room_info=client.room_info,
        output_format="mp4",
        outputs={"segment": "-f", "60": "-segment_time", "1": "-reset_timestamps"},
        record_for=360
    )
```