### PR TITLE
bugfix(fetch_video_data) fix order to prevent duplicate keys

### DIFF
--- a/TikTokLive/client/web/routes/fetch_video_data.py
+++ b/TikTokLive/client/web/routes/fetch_video_data.py
@@ -126,7 +126,7 @@ class FetchVideoDataRoute(ClientRoute):
         if self._ffmpeg is not None:
             raise DuplicateDownloadError("You are already downloading this stream!")
 
-        record_time: Optional[str] = f"-t {record_for}" if record_for and record_for > 0 else None
+        record_time: dict = {str(record_for): "-t"} if record_for and record_for > 0 else {}
         record_data: dict = json.loads(room_info['stream_url']['live_core_sdk_data']['pull_data']['stream_data'])
         record_url_data: dict = record_data['data'][quality.value]['main']
         record_url: str = record_url_data.get(record_format.value) or record_url_data['flv']
@@ -134,11 +134,12 @@ class FetchVideoDataRoute(ClientRoute):
         self._ffmpeg = FFmpeg(
             inputs={**{record_url: None}, **kwargs.pop('inputs', dict())},
             outputs={
-                **kwargs.pop('outputs', dict()),
+                **{v: k for k, v in kwargs.pop('outputs', dict()).items()},
                 **{
-                    str(output_fp): record_time,
+                    **record_time,
+                    str(output_fp): None,
                     output_format or record_format.value: "-f"
-                },
+                }
             },
             global_options=(
                 list(


### PR DESCRIPTION
### Before: We had to use in reverse order but then we can't have duplicate key
```python
    # Start a recording
    client.web.fetch_video_data.start(
        output_fp=f"{event.unique_id}-%03d.mp4",
        room_info=client.room_info,
        output_format="mp4",
        outputs={"segment": "-f", "60": "-segment_time", "1": "-reset_timestamps"},
        record_for=360
    )
```
### After: Use normal order

```python
    # Start a recording
    client.web.fetch_video_data.start(
        output_fp=f"{event.unique_id}-%03d.mp4",
        room_info=client.room_info,
        output_format="mp4",
        outputs = {
            "-f": "segment",
            "-segment_time": "60",
            "-reset_timestamps": "1",
            "-reconnect": "1"
        },
        record_for=360
    )
```
ffmpy swaps key and value: https://github.com/Ch00k/ffmpy/blob/a55e54988bdcc6638ca1d8c0120389efd36d1cea/ffmpy/ffmpy.py#L194


### Please don't merge yet. I think I need to fix ffmpy