### PR TITLE
Fix: Cannot retrieve gifter_level

### DIFF
--- a/TikTokLive/proto/custom_proto.py
+++ b/TikTokLive/proto/custom_proto.py
@@ -194,7 +194,7 @@ class ExtendedUser(User):
         )
 
         if len(matches) > 0:
-            return int(matches[0][1].combine.str)
+            return int(matches[0][1].combine_badge_struct.str)
 
         return None
 

--- a/TikTokLive/proto/proto_utils.py
+++ b/TikTokLive/proto/proto_utils.py
@@ -45,30 +45,30 @@ def badge_match(badge: BadgeStruct, p: re.Pattern) -> Optional[re.Match]:
 
     """
 
-    if badge.display_type == BadgeStructBadgeDisplayType.BADGEDISPLAYTYPE_STRING:
-        match: Optional[re.Match] = p.search(string=badge.str.str)
+    if badge.badge_display_type == BadgeStructBadgeDisplayType.BADGE_DISPLAY_TYPE_STRING:
+        match: Optional[re.Match] = p.search(string=badge.string_badge.content_str)
         return match
 
-    if badge.display_type == BadgeStructBadgeDisplayType.BADGEDISPLAYTYPE_TEXT:
-        match: Optional[re.Match] = p.search(string=badge.text.default_pattern)
+    if badge.badge_display_type == BadgeStructBadgeDisplayType.BADGE_DISPLAY_TYPE_TEXT:
+        match: Optional[re.Match] = p.search(string=badge.text_badge.default_pattern)
         return match
 
-    if badge.display_type == BadgeStructBadgeDisplayType.BADGEDISPLAYTYPE_IMAGE:
+    if badge.badge_display_type == BadgeStructBadgeDisplayType.BADGE_DISPLAY_TYPE_IMAGE:
 
-        for image_url in badge.image.image.url_list:
+        for image_url in badge.image_badge.image_model.m_urls:
             match: Optional[re.Match] = p.search(string=image_url)
             if match:
                 return match
 
         return None
 
-    if badge.display_type == BadgeStructBadgeDisplayType.BADGEDISPLAYTYPE_COMBINE:
+    if badge.badge_display_type == BadgeStructBadgeDisplayType.BADGE_DISPLAY_TYPE_COMBINE:
 
-        match: Optional[re.Match] = p.search(string=badge.combine.str)
+        match: Optional[re.Match] = p.search(string=badge.combine_badge_struct.str)
         if match:
             return match
 
-        for image_url in badge.combine.icon.url_list:
+        for image_url in badge.combine_badge_struct.icon.m_urls:
             match: Optional[re.Match] = p.search(string=image_url)
             if match:
                 return match


### PR DESCRIPTION
Fix issue where AttributeError: 'BadgeStruct' object has no attribute 'display_type' occurs when retrieving gifter_level, and resolve the root cause.