### PR TITLE
fix: update pyproject.toml to include subpackages using find

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,9 @@ interactive = [
 Homepage = "https://github.com/isaackogan/TikTokLive"
 Download = "https://github.com/isaackogan/TikTokLive/releases/tag/v6.4.5.post2"
 
-[tool.setuptools]
-packages = ["TikTokLive"]  # Use find = {} for auto-discovery
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["TikTokLive*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.txt", "*.rst", "*.md"]  # Proper wildcard for including package data


### PR DESCRIPTION
`pip uninstall -y tiktoklive; pip install 'git+https://github.com/isaackogan/TikTokLive#egg=TikTokLive'`

### before ###

```
python tiktoklive_with_ssid.py
Traceback (most recent call last):
  File "tiktoklive_with_ssid.py", line 11, in <module>
    from TikTokLive import TikTokLiveClient
  File "venv/lib/python3.12/site-packages/TikTokLive/__init__.py", line 1, in <module>
    from .client.client import TikTokLiveClient
ModuleNotFoundError: No module named 'TikTokLive.client'
```

### after ###
Working