### PR TITLE
feat(client): add user ID resolution support

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -12,6 +12,7 @@ from pyee.base import Handler
 
 from TikTokLive.client.errors import AlreadyConnectedError, UserOfflineError, UserNotFoundError
 from TikTokLive.client.logger import TikTokLiveLogHandler, LogLevel
+from TikTokLive.client.web.routes.resolve_user_id import FailedResolveUserId
 from TikTokLive.client.web.web_client import TikTokWebClient
 from TikTokLive.client.web.web_settings import WebDefaults
 from TikTokLive.client.ws.ws_client import WebcastWSClient
@@ -33,7 +34,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
     def __init__(
             self,
             # User to connect to
-            unique_id: str,
+            unique_id: str | int,
 
             # Proxies
             web_proxy: Optional[httpx.Proxy] = None,
@@ -41,7 +42,9 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
             # Client kwargs
             web_kwargs: Optional[dict] = None,
-            ws_kwargs: Optional[dict] = None
+            ws_kwargs: Optional[dict] = None,
+
+            is_userid: Optional[bool] = False
     ):
         """
         Instantiate the TikTokLiveClient client
@@ -51,6 +54,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
         :param ws_proxy: An optional proxy used for the WebSocket connection
         :param web_kwargs: Optional arguments used by the HTTP client
         :param ws_kwargs: Optional arguments used by the WebSocket client
+        :param is_userid: Optional argument to resolve userid to unique_id
 
         """
 
@@ -74,6 +78,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
         self.ignore_broken_payload: bool = False
 
         # Properties
+        self._is_userid: bool = is_userid
         self._unique_id: str = self.parse_unique_id(unique_id)
         self._room_id: Optional[int] = None
         self._room_info: Optional[Dict[str, Any]] = None
@@ -125,6 +130,10 @@ class TikTokLiveClient(AsyncIOEventEmitter):
         if self._ws.connected:
             raise AlreadyConnectedError("You can only make one connection per client!")
 
+        if self._unique_id.isdigit() and self._is_userid:
+            resolved_id = await self._web.resolve_user_id(self._unique_id)
+            self._unique_id = unique_id = resolved_id
+
         # <Required> Fetch room ID
         try:
             self._room_id: int = int(room_id or await self._web.fetch_room_id_from_html(self._unique_id))
@@ -155,7 +164,8 @@ class TikTokLiveClient(AsyncIOEventEmitter):
             self._gift_info = await self._web.fetch_gift_list()
 
         # <Required> Fetch the first response
-        initial_webcast_response: ProtoMessageFetchResult = await self._web.fetch_signed_websocket(preferred_agent_id=preferred_agent_id)
+        initial_webcast_response: ProtoMessageFetchResult = await self._web.fetch_signed_websocket(
+            preferred_agent_id=preferred_agent_id)
 
         # Start the websocket connection & return it
         self._event_loop_task = self._asyncio_loop.create_task(
@@ -349,7 +359,8 @@ class TikTokLiveClient(AsyncIOEventEmitter):
                 if event is not None:
                     yield event
 
-    async def _parse_webcast_response_message(self, webcast_response_message: Optional[ProtoMessageFetchResultBaseProtoMessage]) -> List[Event]:
+    async def _parse_webcast_response_message(self, webcast_response_message: Optional[
+        ProtoMessageFetchResultBaseProtoMessage]) -> List[Event]:
         """
         Parse incoming webcast responses into events that can be emitted
 
@@ -376,7 +387,8 @@ class TikTokLiveClient(AsyncIOEventEmitter):
             proto_event: ProtoEvent = event_type().parse(webcast_response_message.payload)
         except Exception:
             if not self.ignore_broken_payload:
-                self._logger.error(traceback.format_exc() + "\nBroken Payload:\n" + str(webcast_response_message.payload))
+                self._logger.error(
+                    traceback.format_exc() + "\nBroken Payload:\n" + str(webcast_response_message.payload))
             return [response_event]
 
         parsed_events: List[Event] = [response_event, proto_event]
@@ -385,7 +397,7 @@ class TikTokLiveClient(AsyncIOEventEmitter):
         # Add the custom event IF not null
         return [custom_event, *parsed_events] if custom_event else parsed_events
 
-    async def is_live(self, unique_id: Optional[str] = None) -> bool:
+    async def is_live(self, unique_id: Optional[str | int] = None) -> bool:
         """
         Check if the client is currently live on TikTok
 
@@ -394,9 +406,18 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         """
 
+        if self._unique_id.isdigit() and self._is_userid:
+            resolved_id = await self._web.resolve_user_id(self._unique_id)
+
+            if not resolved_id:
+                raise FailedResolveUserId(f"Resolved ID is invalid: {resolved_id}")
+
+            self._unique_id = unique_id = resolved_id
+
         return await self._web.fetch_is_live(unique_id=unique_id or self.unique_id)
 
-    async def handle_custom_event(self, response: ProtoMessageFetchResultBaseProtoMessage, event: ProtoEvent) -> Optional[CustomEvent]:
+    async def handle_custom_event(self, response: ProtoMessageFetchResultBaseProtoMessage, event: ProtoEvent) -> \
+            Optional[CustomEvent]:
         """
         Extract CustomEvent events from existing ProtoEvent events
 
@@ -408,7 +429,8 @@ class TikTokLiveClient(AsyncIOEventEmitter):
 
         # LiveEndEvent, LivePauseEvent, LiveUnpauseEvent
         if isinstance(event, ControlEvent):
-            if event.action in {ControlAction.CONTROL_ACTION_STREAM_ENDED, ControlAction.CONTROL_ACTION_STREAM_SUSPENDED}:
+            if event.action in {ControlAction.CONTROL_ACTION_STREAM_ENDED,
+                                ControlAction.CONTROL_ACTION_STREAM_SUSPENDED}:
                 # If the stream is over, disconnect the client. Can't await due to circular dependency.
                 self._asyncio_loop.create_task(self.disconnect())
                 return LiveEndEvent().parse(response.payload)

--- a/TikTokLive/client/web/routes/resolve_user_id.py
+++ b/TikTokLive/client/web/routes/resolve_user_id.py
@@ -1,0 +1,90 @@
+import json
+import re
+from json import JSONDecodeError
+from typing import Optional
+
+from httpx import Response
+
+from TikTokLive.client.errors import TikTokLiveError
+from TikTokLive.client.web.web_base import ClientRoute
+from TikTokLive.client.web.web_settings import WebDefaults
+
+
+class FailedParseAppInfo(TikTokLiveError):
+    """
+    Thrown when the App Info cannot be parsed
+
+    """
+
+
+class FailedResolveUserId(TikTokLiveError):
+    """
+    Thrown when the User ID cant be resolved
+
+    """
+
+
+class ResolveUserId(ClientRoute):
+    """
+    Route to retrieve the room ID for a user
+
+    """
+
+    APP_INFO_PATTERN: re.Pattern = re.compile(
+        r"""<script id="__UNIVERSAL_DATA_FOR_REHYDRATION__" type="application/json">(.*?)</script>""")
+
+    async def __call__(self, user_id: int) -> str:
+        """
+        Fetch the unique_id for a given User ID from the page HTML
+
+        :param user_id: The user's username
+        :return: The unique_id of a User ID
+
+        """
+
+        # Get their User HTML
+        response: Response = await self._web.get(
+            url=WebDefaults.tiktok_app_url + f"/@{user_id}",
+            base_params=False
+        )
+
+        return self.parse_app_info(response.text)
+
+    @classmethod
+    def parse_app_info(cls, html: str) -> str:
+        """
+        Parse the room ID from livestream HTML
+
+        :param html: The HTML to parse from https://tiktok.com/@<user_id>
+        :return: The unique_id of a User ID
+
+        """
+
+        match: Optional[re.Match[str]] = cls.APP_INFO_PATTERN.search(html)
+
+        if match is None:
+            raise FailedParseAppInfo(
+                "Failed to extract data __UNIVERSAL_DATA_FOR_REHYDRATION__, you might be blocked by TikTok.")
+
+        try:
+            app_info: dict = json.loads(match.group(1))
+        except JSONDecodeError:
+            raise FailedParseAppInfo("Failed to extract data, you might be blocked by TikTok.")
+
+        try:
+            unique_id: str = (
+                app_info
+                .get('__DEFAULT_SCOPE__', {})
+                .get('webapp.user-detail', {})
+                .get('userInfo', {})
+                .get('user', {})
+                .get('uniqueId')
+            )
+
+        except Exception:  # Catch errors during key traversal (e.g., AttributeError)
+            raise FailedResolveUserId("Failed to parse user data from JSON")
+
+        if unique_id is None:
+            raise FailedResolveUserId("Failed to resolve User ID to unique_id")
+
+        return unique_id

--- a/TikTokLive/client/web/web_client.py
+++ b/TikTokLive/client/web/web_client.py
@@ -9,6 +9,7 @@ from TikTokLive.client.web.routes.fetch_room_id_live_html import FetchRoomIdLive
 from TikTokLive.client.web.routes.fetch_room_info import FetchRoomInfoRoute
 from TikTokLive.client.web.routes.fetch_signed_websocket import FetchSignedWebSocketRoute
 from TikTokLive.client.web.routes.fetch_video_data import FetchVideoDataRoute
+from TikTokLive.client.web.routes.resolve_user_id import ResolveUserId
 from TikTokLive.client.web.routes.send_room_chat import SendRoomChatRoute
 from TikTokLive.client.web.routes.send_room_gift import SendRoomGiftRoute
 from TikTokLive.client.web.routes.send_room_like import SendRoomLikeRoute
@@ -44,6 +45,7 @@ class TikTokWebClient(TikTokHTTPClient):
         self.send_room_chat: SendRoomChatRoute = SendRoomChatRoute(self)
         self.send_room_like: SendRoomLikeRoute = SendRoomLikeRoute(self)
         self.send_room_gift: SendRoomGiftRoute = SendRoomGiftRoute(self)
+        self.resolve_user_id: ResolveUserId = ResolveUserId(self)
 
         self._logger = TikTokLiveLogHandler.get_logger()
 


### PR DESCRIPTION
### new ###
`client: TikTokLiveClient = TikTokLiveClient(unique_id="@6701514161706304513", is_userid=True)`

This resolves 6701514161706304513 to tv_asahi_news

What's the point of that? You can change the unique_id, but not the user ID.