### PR TITLE
refact: clean up deprecated code and improve initialization logic

### DIFF
--- a/TikTokLive/client/ws/ws_client.py
+++ b/TikTokLive/client/ws/ws_client.py
@@ -104,7 +104,7 @@ class WebcastWSClient:
         if not self.connected:
             return
 
-        print('sending ack', WebcastPushFrame(
+        self._logger.debug('sending ack', WebcastPushFrame(
             payload_type="ack",
             # ID of the WebcastPushMessage for the acknowledgement
             log_id=webcast_push_frame.log_id,

--- a/TikTokLive/events/proto_events.py
+++ b/TikTokLive/events/proto_events.py
@@ -7,6 +7,7 @@ from typing import Union
 
 from TikTokLive.proto.custom_proto import *
 from .base_event import BaseEvent
+from ..proto import Gift
 
 
 class KaraokeQueueListEvent(BaseEvent, WebcastKaraokeQueueListMessage):
@@ -1211,13 +1212,8 @@ class CommentEvent(BaseEvent, WebcastChatMessage):
     at_user: ExtendedUser
 
     @property
-    def user(self):
+    def user(self) -> ExtendedUser:
         """Backwards compatibility for user"""
-        warnings.warn(
-            "CommentEvent.user is deprecated - use CommentEvent.user_info instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
         return self.user_info
 
     @property
@@ -1269,7 +1265,7 @@ class GiftEvent(BaseEvent, WebcastGiftMessage):
     m_gift: ExtendedGift
 
     @property
-    def gift(self) -> ExtendedGift:
+    def gift(self) -> Gift:
         """
         Get the gift object. m_gift is kind of a weird name, so, we'll just call it gift
 
@@ -1282,11 +1278,6 @@ class GiftEvent(BaseEvent, WebcastGiftMessage):
     @property
     def user(self):
         """Backwards compatibility for user"""
-        warnings.warn(
-            "GiftEvent.user is deprecated - use GiftEvent.from_user instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
         return self.from_user
 
     @property

--- a/TikTokLive/proto/custom_proto.py
+++ b/TikTokLive/proto/custom_proto.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 # noinspection PyUnresolvedReferences
 import re
-import warnings
 # noinspection PyUnresolvedReferences
 from typing import Optional, List, Type, TypeVar, Tuple
 
@@ -61,12 +60,7 @@ class ExtendedUser(User):
 
     @property
     def display_id(self):
-        """Backwards compatibility for user"""
-        warnings.warn(
-            "ExtendedUser.display_id is deprecated - use ExtendedUser.username instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
+        """Backwards compatibility for username"""
         return getattr(self, "username", getattr(self, "nick_name", None))
 
     @property
@@ -217,11 +211,15 @@ class ExtendedGift(Gift):
 
     """
 
-    def __init__(self, proto_gift: Gift):
-        self.m_gift = proto_gift
+    def __init__(self, proto_gift: Gift = None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        for attr, value in proto_gift.__dict__.items():
-            setattr(self, attr, value)
+        if proto_gift is not None:
+            self.m_gift = proto_gift
+            for attr, value in proto_gift.__dict__.items():
+                setattr(self, attr, value)
+        else:
+            self.m_gift = None
 
     @property
     def streakable(self) -> bool:


### PR DESCRIPTION
### fixes ###
`TypeError: ExtendedGift.__init__() missing 1 required positional argument: 'proto_gift'`

### commit ###
- Remove deprecated `display_id` warnings and legacy shims in `ExtendedUser`
- Refactor `ExtendedGift` constructor to handle optional `proto_gift` gracefully
- Simplify `GiftEvent.gift` to return base `Gift` type instead of `ExtendedGift`
- Replace debug `print` with proper logger call in WebSocket client