### PR TITLE
fix: resolve AttributeErrors in ExtendedUser.from_user ...

### DIFF
--- a/TikTokLive/client/client.py
+++ b/TikTokLive/client/client.py
@@ -17,7 +17,7 @@ from TikTokLive.client.web.web_client import TikTokWebClient
 from TikTokLive.client.web.web_settings import WebDefaults
 from TikTokLive.client.ws.ws_client import WebcastWSClient
 from TikTokLive.client.ws.ws_connect import WebcastProxy
-from TikTokLive.events import Event, EventHandler
+from TikTokLive.events import Event, EventHandler, ControlEvent
 from TikTokLive.events.custom_events import WebsocketResponseEvent, FollowEvent, ShareEvent, LiveEndEvent, \
     DisconnectEvent, LivePauseEvent, LiveUnpauseEvent, UnknownEvent, CustomEvent, ConnectEvent
 from TikTokLive.events.proto_events import EVENT_MAPPINGS, ProtoEvent

--- a/TikTokLive/events/proto_events.py
+++ b/TikTokLive/events/proto_events.py
@@ -1214,7 +1214,7 @@ class CommentEvent(BaseEvent, WebcastChatMessage):
     @property
     def user(self) -> ExtendedUser:
         """Backwards compatibility for user"""
-        return self.user_info
+        return ExtendedUser.from_user(self.user_info)
 
     @property
     def comment(self) -> str:


### PR DESCRIPTION
fix: resolve AttributeErrors in ExtendedUser.from_user for User to ExtendedUser conversion

- revert https://github.com/isaackogan/TikTokLive/commit/ae220c422eea58a641d9d1583bebb94b1000b43f due to `WebSocket rejected by TikTok due to "illegal secret key".`