### PR TITLE
Fix: room_id type and populate the session ID

### DIFF
--- a/TikTokLive/client/web/routes/send_room_chat.py
+++ b/TikTokLive/client/web/routes/send_room_chat.py
@@ -12,7 +12,7 @@ class SendRoomChatRoute(ClientRoute):
     async def __call__(
             self,
             content: str,
-            room_id: Optional[int] = None,
+            room_id: Optional[str] = None,
             session_id: Optional[str] = None,
     ) -> dict:
         check_authenticated_session_id(session_id)
@@ -20,7 +20,7 @@ class SendRoomChatRoute(ClientRoute):
         payload: dict = {
             "roomId": room_id or self._web.params['room_id'],
             "content": content,
-            "sessionId": ""
+            "sessionId": session_id or self._web.cookies['sessionid']
         }
 
         response: httpx.Response = await self._web.signer.client.post(


### PR DESCRIPTION
### Issues

While testing the latest version 6.5.2, it appears that the room_id parameter in the route couldn't work due to mismatch of types and that the sessionId wasn't populated. 

### Fix
This PR update the send_room_chat.py to accept a room_id of type str and populate the sessionId in the payload using the function parameter or the cookies.