### PR TITLE
fix: Change log_id from -1 to 1 in WebcastPushFrame

### DIFF
--- a/TikTokLive/client/web/routes/fetch_signed_websocket.py
+++ b/TikTokLive/client/web/routes/fetch_signed_websocket.py
@@ -148,7 +148,7 @@ class FetchSignedWebSocketRoute(ClientRoute):
         return extract_webcast_response_message(
             logger=self._logger,
             push_frame=WebcastPushFrame(
-                log_id=-1,
+                log_id=1,
                 payload=data,
                 payload_type="msg"
             ),


### PR DESCRIPTION
Change value to match the validation rule