### PR TITLE
fix: use avatar_thumb in images example

### DIFF
--- a/examples/images.py
+++ b/examples/images.py
@@ -16,9 +16,9 @@ async def on_connect(event: ConnectEvent):
 async def on_comment(event: CommentEvent):
     client.logger.info("Received a comment!")
 
-    # Download the user's avatar (v2 schema: profile_picture is an Image)
+    # Download the user's avatar (only avatar_thumb is populated on comment events)
     image_bytes: bytes = await client.web.fetch_image_data(
-        image=event.user.profile_picture
+        image=event.user.avatar_thumb
     )
 
     # Write to bytes


### PR DESCRIPTION
## Summary
- `CommentEvent.user` only populates `avatar_thumb`, not `profile_picture`, so the images example downloaded no data. Switched to `avatar_thumb`.

## Test plan
- [x] Manually ran `examples/images.py` against a live stream and confirmed the avatar image is downloaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)