### PR TITLE
test: add regression coverage and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[test]"
+
+      - name: Run tests
+        run: python -m pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to TikTokLive
+
+Thank you for taking the time to contribute. TikTok LIVE changes frequently,
+so focused fixes, reproducible reports, and regression tests are especially
+valuable.
+
+## Development setup
+
+TikTokLive supports Python 3.10 through 3.12. Create and activate a virtual
+environment, then install the package with the test dependencies:
+
+```shell
+python -m pip install --upgrade pip
+python -m pip install -e ".[test]"
+```
+
+Run the test suite before opening a pull request:
+
+```shell
+python -m pytest
+```
+
+The existing type-checking workflow can be run locally with:
+
+```shell
+python -m pip install "mypy>=1.10" types-PyYAML jinja2 pyyaml
+python -m mypy --follow-imports=silent TikTokLive scripts/proto
+```
+
+## Pull requests
+
+- Keep each pull request focused on one behavior change.
+- Add or update a regression test for every bug fix when the behavior can be
+  reproduced without contacting TikTok.
+- Do not add live account credentials, session cookies, or unredacted request
+  headers to source files, tests, issues, or pull request descriptions.
+- Explain any behavior that depends on an observed TikTok protocol change and
+  include a minimal, sanitized fixture when possible.
+- Update the README or Sphinx documentation when a public API changes.
+
+## Reporting protocol changes
+
+TikTok protocol changes are most useful when reported with the package version,
+Python version, operating system, the affected event or route, and a sanitized
+stack trace. Avoid attaching complete WebSocket payloads unless all account,
+cookie, and personally identifiable data has been removed.
+
+## Generated files
+
+`TikTokLive/events/proto_events.py` and `TikTokLive/proto/_aliases.py` are
+generated from the scripts under `scripts/proto/`. If a change affects their
+inputs, regenerate both files and include the generated diff in the same pull
+request.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "protobuf3-to-dict>=0.1.5",
     "protobuf>=3.19.4",
     "TikTokLiveProto==0.2.0",
-    "EulerApiSdk>=0.1.0"
+    "EulerApiSdk==0.1.0"
 ]
 
 classifiers = [
@@ -36,6 +36,12 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.3",
+    "pytest-asyncio>=0.24",
 ]
 
 [dependency-groups]
@@ -81,6 +87,10 @@ exclude = [
     "build/",
     "dist/",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [project.urls]
 Homepage = "https://github.com/isaackogan/TikTokLive"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,49 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from TikTokLive import TikTokLiveClient
+from TikTokLive.client.client import _truncate_payload
+from TikTokLive.client.errors import AlreadyConnectedError
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("@creator", "creator"),
+        ("creator", "creator"),
+        ("https://www.tiktok.com/@creator/live", "creator"),
+        (123456789, "123456789"),
+    ],
+)
+def test_parse_unique_id(value: str | int, expected: str) -> None:
+    assert TikTokLiveClient.parse_unique_id(value) == expected
+
+
+async def test_is_live_resolves_the_requested_user_id() -> None:
+    client = TikTokLiveClient(unique_id="@original")
+    client._resolve_user_id = AsyncMock(return_value="resolved_creator")
+    client.web.fetch_is_live = AsyncMock(return_value=True)
+
+    assert await client.is_live("@requested") is True
+    client._resolve_user_id.assert_awaited_once_with("@requested")
+    client.web.fetch_is_live.assert_awaited_once_with(unique_id="resolved_creator")
+    assert client.unique_id == "resolved_creator"
+
+
+async def test_start_rejects_a_second_connection(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = TikTokLiveClient(unique_id="@creator")
+    monkeypatch.setattr(type(client._ws), "connected", property(lambda _: True))
+
+    with pytest.raises(AlreadyConnectedError, match="one connection"):
+        await client.start()
+
+
+def test_truncate_payload_preserves_short_payloads() -> None:
+    assert _truncate_payload(b"payload") == "b'payload'"
+
+
+def test_truncate_payload_reports_omitted_bytes() -> None:
+    payload = b"a" * 33
+
+    assert _truncate_payload(payload) == "b'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'...(+1 more bytes)"

--- a/tests/test_web_utils.py
+++ b/tests/test_web_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from TikTokLive.client.errors import AuthenticatedWebSocketConnectionError
+from TikTokLive.client.web.web_settings import WebDefaults
+from TikTokLive.client.web.web_utils import check_authenticated_session
+
+
+def test_anonymous_session_is_allowed_when_not_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("WHITELIST_AUTHENTICATED_SESSION_ID_HOST", raising=False)
+
+    assert check_authenticated_session(None, None, session_required=False) is False
+
+
+def test_missing_session_is_rejected_when_required() -> None:
+    with pytest.raises(ValueError, match="Session ID required"):
+        check_authenticated_session(None, None, session_required=True)
+
+
+def test_authenticated_session_requires_an_explicitly_authorized_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("WHITELIST_AUTHENTICATED_SESSION_ID_HOST", raising=False)
+
+    with pytest.raises(AuthenticatedWebSocketConnectionError, match="BLOCKED"):
+        check_authenticated_session("session-id", "useast1a", session_required=False)
+
+
+def test_authenticated_session_accepts_the_configured_signing_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    host = WebDefaults.tiktok_sign_url.split("://", maxsplit=1)[1]
+    monkeypatch.setenv("WHITELIST_AUTHENTICATED_SESSION_ID_HOST", host)
+
+    assert check_authenticated_session("session-id", "useast1a", session_required=False) is True


### PR DESCRIPTION
## Summary

- add a pytest-based regression suite for client lifecycle and authenticated-session safeguards
- run the suite in GitHub Actions on Python 3.10, 3.11, and 3.12
- document local setup, test expectations, protocol-reporting guidance, and generated files in `CONTRIBUTING.md`
- pin `EulerApiSdk` to the last release that still exports `sign_webcast_url`

## Why

The project had type checking but no executable regression-test job. The dependency range for `EulerApiSdk` also allowed releases that removed an import used by `TikTokLive.client.web.web_signer`, causing a clean installation to fail during package import.

## Validation

- created a fresh virtual environment without package-cache reuse
- installed the project with `python -m pip install -e .[test]`
- verified the `EulerApiSdk.api.tik_tok_live.sign_webcast_url` import contract
- ran `python -m pytest -q` successfully: 12 passed
- ran the repository's existing curated mypy command successfully