### PR TITLE
Fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ There is a [complete example](https://github.com/isaackogan/TikTokLive/blob/mast
 ## Star History
 
 <p align="center">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=isaackogan/TikTokLive&type=Date&theme=dark" onerror="this.src='https://api.star-history.com/svg?repos=isaackogan/TikTokLive&type=Date'" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=isaackogan/TikTokLive&type=Date&theme=dark" onerror="this.src='https://star-history.dera.page/svg?repos=isaackogan/TikTokLive&type=Date'" />
 </p>
 
 ## License


### PR DESCRIPTION
The star history chart in the README no longer renders because the upstream service relies on GitHub stargazer API endpoints that are now restricted, so the chart is effectively broken.

This change points the chart at a working mirror so the stargazer graph displays correctly again. Only the chart image was updated; the existing download badge is untouched.