### PR TITLE
SEO: restore the docs site and make it a dofollow backlink source

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,9 @@ jobs:
         working-directory: docs/src
         run: make html
 
+      - name: Verify SEO invariants
+        run: python scripts/seo/verify_seo.py docs/dist/html
+
       - name: Add .nojekyll
         run: touch docs/dist/html/.nojekyll
 

--- a/docs/src/_templates/page.html
+++ b/docs/src/_templates/page.html
@@ -1,0 +1,13 @@
+{#
+  Extends Furo's own page.html. The "!" prefix tells Sphinx to load the theme's
+  template rather than recursing into this override.
+#}
+{% extends "!page.html" %}
+
+{% block footer %}
+  {{ super() }}
+  <div class="euler-footer">
+    Request signing and production infrastructure provided by
+    <a href="https://www.eulerstream.com/">eulerstream.com</a>.
+  </div>
+{% endblock footer %}

--- a/docs/src/_templates/page.html
+++ b/docs/src/_templates/page.html
@@ -8,6 +8,6 @@
   {{ super() }}
   <div class="euler-footer">
     Request signing and production infrastructure provided by
-    <a href="https://www.eulerstream.com/">eulerstream.com</a>.
+    <a href="https://www.eulerstream.com/docs">eulerstream.com</a>.
   </div>
 {% endblock footer %}

--- a/docs/src/_templates/sidebar/eulerstream.html
+++ b/docs/src/_templates/sidebar/eulerstream.html
@@ -1,0 +1,15 @@
+{#
+  Sitewide attribution block. TikTokLive depends on Euler Stream for request
+  signing, so this is a genuine dependency disclosure, not an ad.
+  Anchor text is deliberately varied across sidebar and footer.
+#}
+<div class="sidebar-euler">
+  <span class="sidebar-euler__label">Production use</span>
+  <p class="sidebar-euler__text">
+    TikTokLive is a reverse-engineering project. For guaranteed uptime, use the
+    managed <a class="sidebar-euler__link"
+      href="https://www.eulerstream.com/websockets">TikTok LIVE WebSocket API</a>
+    by <a class="sidebar-euler__link"
+      href="https://www.eulerstream.com/">Euler Stream</a>.
+  </p>
+</div>

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -46,6 +46,8 @@ extensions = [
     "myst_parser",
     "sphinx_rtd_theme",
     'sphinx_search.extension',
+    "sphinx_sitemap",
+    "sphinxext.opengraph",
 ]
 
 html_logo = "logo.png"
@@ -64,6 +66,28 @@ html_short_title = "TikTokLive Docs"
 # Required for canonical tags and by sphinx-sitemap. Must match the live
 # Pages URL exactly, trailing slash included.
 html_baseurl = "https://isaackogan.github.io/TikTokLive/"
+
+# -- Sitemap ------------------------------------------------------------------
+# The default scheme is "{lang}{version}{link}", which emits broken URLs when
+# neither language nor version dirs are in use. "{link}" is what a flat,
+# single-version site needs.
+sitemap_url_scheme = "{link}"
+sitemap_filename = "sitemap.xml"
+
+# -- Open Graph / social cards -------------------------------------------------
+ogp_site_url = html_baseurl
+ogp_site_name = "TikTokLive Documentation"
+ogp_type = "website"
+ogp_image = (
+    "https://raw.githubusercontent.com/isaackogan/TikTokLive"
+    "/master/.github/SquareLogo.png"
+)
+ogp_image_alt = "TikTokLive — TikTok LIVE API for Python"
+ogp_description_length = 200
+ogp_enable_meta_description = True
+ogp_custom_meta_tags = [
+    '<meta name="twitter:card" content="summary_large_image" />',
+]
 
 html_theme_options = {
     "light_css_variables": {

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -109,7 +109,12 @@ ogp_image = (
     "/master/.github/SquareLogo.png"
 )
 ogp_image_alt = "TikTokLive — TikTok LIVE API for Python"
-ogp_description_length = 200
+# sphinxext-opengraph derives og:description from the doctree and concatenates
+# paragraphs until this limit, so the limit is sized to stop exactly at the end
+# of the homepage's opening paragraph (150 chars). A larger value would pull in
+# the next paragraph and truncate mid-word; this keeps the social preview a
+# complete sentence.
+ogp_description_length = 155
 ogp_enable_meta_description = True
 ogp_custom_meta_tags = [
     '<meta name="twitter:card" content="summary_large_image" />',

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -4,7 +4,6 @@
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 import importlib
-import json
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -13,9 +12,20 @@ import json
 #
 import os
 import sys
+import re
+from pathlib import Path
 
-manifest = json.loads(open("manifest.json", "r").read())
-version = "v" + manifest["version"]
+# Single source of truth: the file release.yml stamps on every release.
+# Reading it textually (rather than importing TikTokLive) keeps conf.py
+# importable without the package's runtime dependencies installed.
+_VERSION_FILE = Path(__file__).resolve().parents[2] / "TikTokLive" / "__version__.py"
+_VERSION_MATCH = re.search(
+    r'PACKAGE_VERSION\s*:\s*str\s*=\s*"([^"]+)"', _VERSION_FILE.read_text()
+)
+if _VERSION_MATCH is None:
+    raise RuntimeError(f"Could not parse PACKAGE_VERSION from {_VERSION_FILE}")
+
+version = release = _VERSION_MATCH.group(1)
 
 sys.path.insert(0, os.path.abspath('../../'))
 
@@ -44,9 +54,16 @@ html_logo = "logo.png"
 templates_path = ['_templates']
 
 html_theme = "furo"
-html_title = project + " " + version
 
-print("Building for version", html_title)
+# The single highest-leverage on-page string on the site. Keyword-led, and
+# deliberately free of the version number so the <title> is stable across
+# releases (a churning title resets accumulated relevance).
+html_title = "TikTok LIVE API for Python — TikTokLive Documentation"
+html_short_title = "TikTokLive Docs"
+
+# Required for canonical tags and by sphinx-sitemap. Must match the live
+# Pages URL exactly, trailing slash included.
+html_baseurl = "https://isaackogan.github.io/TikTokLive/"
 
 html_theme_options = {
     "light_css_variables": {
@@ -54,7 +71,8 @@ html_theme_options = {
     "dark_css_variables": {
         "color-problematic": "#80aeef",
         "sidebar-filter": "invert(0.95)"
-    }
+    },
+    "sidebar_hide_name": True,
 }
 
 # List of patterns, relative to source directory, that match files and

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -142,6 +142,11 @@ html_js_files = [
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['static']
+
+# Files copied verbatim to the site root. Used for the Google Search Console
+# verification file, which must be served at an exact path.
+html_extra_path = ["extra"]
+
 html_permalinks_icon = "#"
 
 source_suffix = {

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -57,6 +57,22 @@ templates_path = ['_templates']
 
 html_theme = "furo"
 
+# Furo's defaults, copied verbatim from its theme.conf, with our attribution
+# block inserted after navigation. Overriding html_sidebars replaces the whole
+# list, so omitting any entry here silently removes it from the sidebar.
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/eulerstream.html",
+        "sidebar/ethical-ads.html",
+        "sidebar/scroll-end.html",
+        "sidebar/variant-selector.html",
+    ]
+}
+
 # The single highest-leverage on-page string on the site. Keyword-led, and
 # deliberately free of the version number so the <title> is stable across
 # releases (a churning title resets accumulated relevance).
@@ -73,6 +89,16 @@ html_baseurl = "https://isaackogan.github.io/TikTokLive/"
 # single-version site needs.
 sitemap_url_scheme = "{link}"
 sitemap_filename = "sitemap.xml"
+
+# Utility and stub pages carry no unique crawlable content — search.html is
+# even stamped noindex by Furo — so they are not advertised in the sitemap.
+# modules.html is a 7-line stub whose entire body is one toctree link.
+sitemap_excludes = [
+    "search.html",
+    "genindex.html",
+    "py-modindex.html",
+    "modules.html",
+]
 
 # -- Open Graph / social cards -------------------------------------------------
 ogp_site_url = html_baseurl

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -1,13 +1,48 @@
-.. MD -> .. mdinclude:: ../README.md
+.. meta::
+   :description: Official documentation for TikTokLive, the unofficial TikTok LIVE API for Python. Connect to any TikTok livestream and receive real-time comments, gifts, likes, follows and viewer counts.
+   :keywords: tiktok live api, tiktok api python, tiktoklive, tiktok live chat, tiktok websocket
 
-TikTokLive Docs
-==================
+TikTok LIVE API for Python
+==========================
 
-The following subpackages exist for TikTokLive:
+This is the reference documentation for **TikTokLive**, the unofficial
+Python client for the TikTok LIVE Webcast service. It connects to any public
+TikTok livestream using only a creator's ``@unique_id`` and emits real-time
+events for comments, gifts, likes, follows, shares, viewer counts and battles.
+
+These docs cover the full public API surface. If you are new, start with the
+quickstart in the project overview below, then move to the module reference.
+
+What is in these docs
+---------------------
+
+- :doc:`TikTokLive` — the top-level package: client, events, protobuf schema
+- :doc:`TikTokLive.client` — ``TikTokLiveClient``, connection lifecycle, configuration
+- :doc:`TikTokLive.client.web` — the HTTP client and its route methods
+- :doc:`TikTokLive.client.ws` — the Webcast WebSocket layer
+- :doc:`TikTokLive.events` — every event type you can subscribe to
+- :doc:`TikTokLive.proto` — generated protobuf message definitions
+
+A note on production use
+------------------------
+
+TikTokLive is a reverse-engineering project, not a supported vendor API.
+TikTok can and does change the Webcast protocol without notice. For workloads
+that need an uptime guarantee, the managed
+`TikTok LIVE WebSocket API <https://www.eulerstream.com/websockets>`_ from
+`Euler Stream <https://www.eulerstream.com/>`_ handles signing, scaling and
+protocol drift for you.
+
+Module reference
+----------------
 
 .. toctree::
    :maxdepth: 3
 
    TikTokLive
+
+Project overview
+----------------
+
 .. include:: ../../README.md
    :parser: myst_parser.sphinx_

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -5,11 +5,11 @@
 TikTok LIVE API for Python
 ==========================
 
-This is the reference documentation for **TikTokLive**, the unofficial
-Python client for the TikTok LIVE Webcast service. It connects to any public
-TikTok livestream using only a creator's ``@unique_id`` and emits real-time
-events for comments, gifts, likes, follows, shares, viewer counts and battles.
+TikTokLive is the unofficial TikTok LIVE API for Python: real-time comments,
+gifts, likes, follows and viewer counts from any public TikTok livestream.
 
+It also emits shares, battles and 50+ other event types. Connecting requires
+only a creator's @unique_id -- no login, credentials, or app registration.
 These docs cover the full public API surface. If you are new, start with the
 quickstart in the project overview below, then move to the module reference.
 

--- a/docs/src/manifest.json
+++ b/docs/src/manifest.json
@@ -1,7 +1,0 @@
-{
-  "name": "TikTokLive",
-  "license": "MIT",
-  "author": "Isaac Kogan",
-  "version": "6.6.5",
-  "email": "info@isaackogan.com"
-}

--- a/docs/src/requirements.txt
+++ b/docs/src/requirements.txt
@@ -3,3 +3,5 @@ sphinx-rtd-theme
 myst-parser
 furo
 readthedocs-sphinx-search
+sphinx-sitemap
+sphinxext-opengraph

--- a/docs/src/static/css/custom.css
+++ b/docs/src/static/css/custom.css
@@ -6,3 +6,34 @@
 img.sidebar-logo {
     filter: var(--sidebar-filter);
 }
+
+.sidebar-euler {
+    margin: 1rem var(--sidebar-item-spacing-horizontal, 1rem);
+    padding: 0.75rem 0.9rem;
+    border: 1px solid var(--color-background-border, #ddd);
+    border-radius: 8px;
+    background: var(--color-background-secondary, #f8f9fb);
+}
+
+.sidebar-euler__label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-foreground-muted, #6b6b6b);
+    margin-bottom: 0.35rem;
+}
+
+.sidebar-euler__text {
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    color: var(--color-foreground-secondary, #4a4a4a);
+}
+
+.euler-footer {
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--color-foreground-muted, #6b6b6b);
+}

--- a/docs/superpowers/plans/2026-08-17-seo-backlink-optimization.md
+++ b/docs/superpowers/plans/2026-08-17-seo-backlink-optimization.md
@@ -1,0 +1,1127 @@
+# SEO & Backlink Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore the TikTokLive documentation site and turn it into an indexable, dofollow backlink source for `www.eulerstream.com`, then publish the rewritten README to PyPI via a 7.0.0 stable release.
+
+**Architecture:** GitHub Pages is switched from legacy mode to workflow mode so the existing `actions/deploy-pages` build is actually served. SEO is added declaratively through Sphinx extensions and Furo template overrides in `docs/src/`, never by post-processing built HTML. A standalone verification script asserts the SEO invariants against the built output and runs as a gate inside `docs.yml`, so regressions fail the build rather than silently degrading rankings.
+
+**Tech Stack:** Sphinx 9.x, Furo theme, `sphinx-sitemap` 2.9.0, `sphinxext-opengraph` 0.13.0, MyST parser, GitHub Actions, `gh` CLI, setuptools/PyPI trusted publishing.
+
+**Spec:** `docs/superpowers/specs/2026-08-17-seo-backlink-design.md`
+
+## Global Constraints
+
+- Canonical site URL is exactly `https://isaackogan.github.io/TikTokLive/` (trailing slash). Never `TikTok-Live-Api`.
+- All new docs dependencies go in `docs/src/requirements.txt` only. They must never enter `pyproject.toml` `[project].dependencies` — they must not ship in the wheel.
+- Links to `eulerstream.com` emitted by our own templates must never carry `rel="nofollow"`.
+- Anchor text to `eulerstream.com` must be varied. No single exact-match anchor repeated sitewide.
+- Python floor is 3.10 (`requires-python = ">=3.10"`); `[tool.mypy] python_version = "3.10"` must stay in lockstep.
+- Sphinx source dir is `docs/src`; build output is `docs/dist/html` (gitignored via the `dist` entry in `.gitignore`).
+- The version displayed in docs must derive from `TikTokLive/__version__.py`, the single file `release.yml` stamps.
+- Work happens on branch `seo/backlink-optimization`. `release.yml` enforces `master`, so the release is dispatched only after merge.
+
+---
+
+### Task 1: Clear the stray edit and establish a green baseline
+
+**Files:**
+- Modify: `TikTokLive/client/web/routes/fetch_signed_websocket.py:184`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a clean working tree and a known-green test/lint baseline that every later task is measured against.
+
+- [ ] **Step 1: Inspect the stray edit**
+
+```bash
+git diff TikTokLive/client/web/routes/fetch_signed_websocket.py
+```
+
+Expected: a single added line containing `2` at module level, with no trailing newline. This is an accidental keystroke, not intentional code.
+
+- [ ] **Step 2: Revert it**
+
+```bash
+git checkout -- TikTokLive/client/web/routes/fetch_signed_websocket.py
+git status --porcelain
+```
+
+Expected: empty output. If the file still shows as modified, stop and ask — the change may be intentional after all.
+
+- [ ] **Step 3: Run the test suite**
+
+```bash
+python -m pytest -q
+```
+
+Expected: PASS. Record the count. If anything fails here it is pre-existing and must be reported before continuing, not fixed silently as part of this plan.
+
+- [ ] **Step 4: Run mypy exactly as CI does**
+
+```bash
+python -m mypy --follow-imports=silent \
+  TikTokLive/proto/__init__.py TikTokLive/proto/proto_utils.py \
+  TikTokLive/events/custom_events.py TikTokLive/client/__init__.py \
+  TikTokLive/client/ws/ws_utils.py TikTokLive/client/web/web_client.py \
+  TikTokLive/client/web/web_settings.py TikTokLive/client/web/web_utils.py \
+  scripts/proto/gen_aliases.py scripts/proto/gen_events.py
+```
+
+Expected: PASS (`Success: no issues found`).
+
+- [ ] **Step 5: No commit**
+
+Nothing to commit — this task only reverts an unstaged accident. Proceed to Task 2.
+
+---
+
+### Task 2: Restore GitHub Pages (the unblock)
+
+**Files:**
+- No repo files. This is a GitHub API configuration change.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a live site at `https://isaackogan.github.io/TikTokLive/` serving real HTML. Every later task's verification depends on this being true.
+
+Do this **before** the SEO work, against current `master` content. It proves the deploy pipeline works in isolation, so if a later task breaks the site you know the cause is your change and not the pipeline.
+
+- [ ] **Step 1: Confirm the current broken state**
+
+```bash
+gh api repos/isaackogan/TikTokLive/pages --jq '{build_type, status, source}'
+curl -sS -o /dev/null -w "%{http_code}\n" -L https://isaackogan.github.io/TikTokLive/
+```
+
+Expected: `build_type: "legacy"`, and HTTP `404`.
+
+- [ ] **Step 2: Confirm with the maintainer before mutating live config**
+
+This changes a public, live site. Ask explicitly, then proceed. Do not bundle it silently with other work.
+
+- [ ] **Step 3: Flip Pages to workflow mode**
+
+```bash
+gh api -X PUT repos/isaackogan/TikTokLive/pages -f build_type=workflow
+gh api repos/isaackogan/TikTokLive/pages --jq '{build_type, status}'
+```
+
+Expected: `build_type: "workflow"`.
+
+- [ ] **Step 4: Trigger a deploy from master**
+
+```bash
+gh workflow run docs.yml --repo isaackogan/TikTokLive --ref master
+sleep 30
+gh run list --repo isaackogan/TikTokLive --workflow=docs.yml --limit 1
+```
+
+Wait for the run to reach `completed / success`.
+
+- [ ] **Step 5: Verify the site is actually alive**
+
+```bash
+curl -sS -o /tmp/docs.html -w "status=%{http_code}\n" -L https://isaackogan.github.io/TikTokLive/
+grep -oE '<title>[^<]*</title>' /tmp/docs.html
+```
+
+Expected: `status=200`, and a real Sphinx title — **not** "Site not found" and not "Page not found". If it still 404s, wait 60s for CDN propagation and retry before investigating further.
+
+- [ ] **Step 6: No commit**
+
+No repo files changed. Record in the PR description that Pages `build_type` was flipped, since it is invisible in the diff.
+
+---
+
+### Task 3: Write the SEO verification script (the failing test)
+
+**Files:**
+- Create: `scripts/seo/verify_seo.py`
+
+**Interfaces:**
+- Consumes: a built Sphinx HTML tree (default `docs/dist/html`).
+- Produces: CLI `python scripts/seo/verify_seo.py [build_dir]`, exit `0` on pass and `1` on failure, printing one line per check. Tasks 4-8 each turn specific checks from FAIL to PASS. Task 11 wires it into `docs.yml`.
+
+This is the plan's test harness. Written first, deliberately failing, so every later task has an objective pass condition.
+
+- [ ] **Step 1: Write the script**
+
+```python
+#!/usr/bin/env python3
+"""Assert the SEO invariants of the built documentation.
+
+Run against a built Sphinx HTML tree::
+
+    python scripts/seo/verify_seo.py docs/dist/html
+
+Exits non-zero if any invariant is violated. Wired into docs.yml so an SEO
+regression fails the build instead of silently degrading rankings.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BASE_URL = "https://isaackogan.github.io/TikTokLive/"
+EULER_HOST = "eulerstream.com"
+
+failures: list[str] = []
+passes: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    (passes if ok else failures).append(name)
+    print(f"{'PASS' if ok else 'FAIL'}  {name}{f' :: {detail}' if detail and not ok else ''}")
+
+
+def main(build_dir: str = "docs/dist/html") -> int:
+    root = Path(build_dir)
+    if not root.is_dir():
+        print(f"FAIL  build directory missing: {root}")
+        return 1
+
+    pages = sorted(root.rglob("*.html"))
+    index = root / "index.html"
+
+    check("index.html exists", index.is_file())
+    if not index.is_file():
+        return 1
+
+    index_html = index.read_text(encoding="utf-8", errors="replace")
+
+    # -- Title -------------------------------------------------------------
+    title = re.search(r"<title>(.*?)</title>", index_html, re.S)
+    title_text = title.group(1).strip() if title else ""
+    check("homepage title contains 'TikTok LIVE API'",
+          "tiktok live api" in title_text.lower(), title_text)
+    check("homepage title has no stale version",
+          "6.6.5" not in title_text, title_text)
+
+    # -- Canonical ---------------------------------------------------------
+    missing_canonical = [
+        p.relative_to(root).as_posix()
+        for p in pages
+        if 'rel="canonical"' not in p.read_text(encoding="utf-8", errors="replace")
+    ]
+    check("every page has rel=canonical", not missing_canonical,
+          f"{len(missing_canonical)} missing, e.g. {missing_canonical[:3]}")
+
+    check("canonical points at the correct base URL",
+          f'rel="canonical" href="{BASE_URL}' in index_html
+          or f'href="{BASE_URL}" rel="canonical"' in index_html)
+
+    # -- Open Graph + meta description ------------------------------------
+    check("homepage has og:title", 'property="og:title"' in index_html)
+    check("homepage has og:description", 'property="og:description"' in index_html)
+    check("homepage has og:image", 'property="og:image"' in index_html)
+    check("homepage has meta description", 'name="description"' in index_html)
+
+    # -- Sitemap -----------------------------------------------------------
+    sitemap = root / "sitemap.xml"
+    check("sitemap.xml exists", sitemap.is_file())
+    if sitemap.is_file():
+        sitemap_xml = sitemap.read_text(encoding="utf-8")
+        check("sitemap uses the canonical base URL", BASE_URL in sitemap_xml)
+        check("sitemap has no unresolved {lang}/{version} placeholders",
+              "{lang}" not in sitemap_xml and "{version}" not in sitemap_xml)
+        check("sitemap lists more than one URL", sitemap_xml.count("<loc>") > 1,
+              f"{sitemap_xml.count('<loc>')} <loc> entries")
+
+    # -- Dofollow link profile --------------------------------------------
+    anchor_re = re.compile(r"<a\b[^>]*>", re.I)
+    nofollowed: list[str] = []
+    pages_with_euler = 0
+    for p in pages:
+        html = p.read_text(encoding="utf-8", errors="replace")
+        euler_anchors = [a for a in anchor_re.findall(html) if EULER_HOST in a]
+        if euler_anchors:
+            pages_with_euler += 1
+        nofollowed += [
+            f"{p.relative_to(root).as_posix()}: {a[:90]}"
+            for a in euler_anchors
+            if "nofollow" in a.lower()
+        ]
+
+    check("no eulerstream.com link is nofollowed", not nofollowed,
+          f"{len(nofollowed)} nofollowed, e.g. {nofollowed[:2]}")
+    check("eulerstream.com linked from every page",
+          pages_with_euler == len(pages),
+          f"{pages_with_euler}/{len(pages)} pages")
+
+    # -- Anchor diversity --------------------------------------------------
+    anchor_text_re = re.compile(
+        r"<a\b[^>]*href=\"[^\"]*" + re.escape(EULER_HOST) + r"[^\"]*\"[^>]*>(.*?)</a>",
+        re.I | re.S,
+    )
+    anchors = {
+        re.sub(r"<[^>]+>", "", m).strip().lower()
+        for m in anchor_text_re.findall(index_html)
+        if re.sub(r"<[^>]+>", "", m).strip()
+    }
+    check("homepage uses varied anchor text", len(anchors) >= 3,
+          f"{len(anchors)} distinct: {sorted(anchors)[:5]}")
+
+    print(f"\n{len(passes)} passed, {len(failures)} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(*sys.argv[1:2]))
+```
+
+- [ ] **Step 2: Build the docs as they are today**
+
+```bash
+python -m venv /tmp/seodocs
+/tmp/seodocs/bin/pip install -q -e . -r docs/src/requirements.txt
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+```
+
+Expected: build succeeds and `docs/dist/html/index.html` exists.
+
+- [ ] **Step 3: Run the script and verify it FAILS**
+
+```bash
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+```
+
+Expected: `exit=1`. Specifically these must FAIL, since nothing has been implemented yet: title checks, canonical, all four og/meta checks, all sitemap checks, and the "linked from every page" check. This failing output is the task's deliverable — confirm it before moving on.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/seo/verify_seo.py
+git commit -m "test: add SEO invariant verification script for built docs"
+```
+
+---
+
+### Task 4: Fix the version source and page titles in conf.py
+
+**Files:**
+- Modify: `docs/src/conf.py:1-50`
+- Delete: `docs/src/manifest.json`
+
+**Interfaces:**
+- Consumes: `TikTokLive/__version__.py`, which defines `PACKAGE_VERSION: str`.
+- Produces: module-level `version`, `release`, and `html_baseurl` in `conf.py`. Task 5 reads `html_baseurl` for sitemap and OG config.
+
+- [ ] **Step 1: Replace the manifest-based version block**
+
+In `docs/src/conf.py`, delete `import json` and these two lines:
+
+```python
+manifest = json.loads(open("manifest.json", "r").read())
+version = "v" + manifest["version"]
+```
+
+Replace with:
+
+```python
+import re
+from pathlib import Path
+
+# Single source of truth: the file release.yml stamps on every release.
+# Reading it textually (rather than importing TikTokLive) keeps conf.py
+# importable without the package's runtime dependencies installed.
+_VERSION_FILE = Path(__file__).resolve().parents[2] / "TikTokLive" / "__version__.py"
+_VERSION_MATCH = re.search(
+    r'PACKAGE_VERSION\s*:\s*str\s*=\s*"([^"]+)"', _VERSION_FILE.read_text()
+)
+if _VERSION_MATCH is None:
+    raise RuntimeError(f"Could not parse PACKAGE_VERSION from {_VERSION_FILE}")
+
+version = release = _VERSION_MATCH.group(1)
+```
+
+- [ ] **Step 2: Set the SEO title and base URL**
+
+Replace this line:
+
+```python
+html_title = project + " " + version
+```
+
+with:
+
+```python
+# The single highest-leverage on-page string on the site. Keyword-led, and
+# deliberately free of the version number so the <title> is stable across
+# releases (a churning title resets accumulated relevance).
+html_title = "TikTok LIVE API for Python — TikTokLive Documentation"
+html_short_title = "TikTokLive Docs"
+
+# Required for canonical tags and by sphinx-sitemap. Must match the live
+# Pages URL exactly, trailing slash included.
+html_baseurl = "https://isaackogan.github.io/TikTokLive/"
+```
+
+Also delete the now-misleading `print("Building for version", html_title)` line.
+
+- [ ] **Step 3: Hide the long title in the sidebar**
+
+The sidebar already shows `logo.png`, and the new `html_title` is too long to render there. In `html_theme_options`, add:
+
+```python
+    "sidebar_hide_name": True,
+```
+
+- [ ] **Step 4: Delete the now-unused manifest**
+
+```bash
+git rm docs/src/manifest.json
+grep -rn "manifest.json" docs/ scripts/ .github/ || echo "no remaining readers"
+```
+
+Expected: `no remaining readers`.
+
+- [ ] **Step 5: Rebuild and verify the title checks now pass**
+
+```bash
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+```
+
+Expected: still `exit=1` overall, but these three now PASS: "homepage title contains 'TikTok LIVE API'", "homepage title has no stale version", and "every page has rel=canonical" (Sphinx emits canonical automatically once `html_baseurl` is set).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/src/conf.py
+git commit -m "docs: derive version from __version__.py, add SEO title and baseurl
+
+Kills the stale-title drift at the source: conf.py read manifest.json,
+pinned at 6.6.5, so every page rendered 'TikTokLive v6.6.5'."
+```
+
+---
+
+### Task 5: Add sitemap and Open Graph extensions
+
+**Files:**
+- Modify: `docs/src/requirements.txt`
+- Modify: `docs/src/conf.py` (extensions list, new config block)
+
+**Interfaces:**
+- Consumes: `html_baseurl` from Task 4.
+- Produces: `sitemap.xml` at the build root, plus `og:*`, `twitter:*` and `<meta name="description">` on every page.
+
+- [ ] **Step 1: Add the dependencies**
+
+Append to `docs/src/requirements.txt`:
+
+```
+sphinx-sitemap
+sphinxext-opengraph
+```
+
+Install them:
+
+```bash
+/tmp/seodocs/bin/pip install -q sphinx-sitemap sphinxext-opengraph
+```
+
+- [ ] **Step 2: Register the extensions**
+
+In `docs/src/conf.py`, add these two entries to the `extensions` list:
+
+```python
+    "sphinx_sitemap",
+    "sphinxext.opengraph",
+```
+
+Note the module names differ in style: underscore for sitemap, dotted for opengraph. Both are correct.
+
+- [ ] **Step 3: Configure them**
+
+Add after the `html_baseurl` line:
+
+```python
+# -- Sitemap ----------------------------------------------------------------
+# The default scheme is "{lang}{version}{link}", which emits broken URLs when
+# neither language nor version dirs are in use. "{link}" is what a flat,
+# single-version site needs.
+sitemap_url_scheme = "{link}"
+sitemap_filename = "sitemap.xml"
+
+# -- Open Graph / social cards ----------------------------------------------
+ogp_site_url = html_baseurl
+ogp_site_name = "TikTokLive Documentation"
+ogp_type = "website"
+ogp_image = (
+    "https://raw.githubusercontent.com/isaackogan/TikTokLive"
+    "/master/.github/SquareLogo.png"
+)
+ogp_image_alt = "TikTokLive — TikTok LIVE API for Python"
+ogp_description_length = 200
+ogp_enable_meta_description = True
+ogp_custom_meta_tags = [
+    '<meta name="twitter:card" content="summary_large_image" />',
+]
+```
+
+- [ ] **Step 4: Rebuild and verify**
+
+```bash
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+ls -la docs/dist/html/sitemap.xml
+head -12 docs/dist/html/sitemap.xml
+```
+
+Expected: all four og/meta checks PASS, and all four sitemap checks PASS. The sitemap must contain absolute `https://isaackogan.github.io/TikTokLive/...` URLs with no literal `{lang}` or `{version}`. Still `exit=1` overall — link-profile checks remain.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/requirements.txt docs/src/conf.py
+git commit -m "docs: add sitemap.xml and Open Graph metadata"
+```
+
+---
+
+### Task 6: Give the homepage unique content
+
+**Files:**
+- Modify: `docs/src/index.rst`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a homepage that is no longer a near-duplicate of the GitHub and PyPI renderings of README.md, plus an explicit `<meta name="description">` for the homepage.
+
+The homepage currently `include`s README.md wholesale, making it a near-exact copy of `github.com/isaackogan/TikTokLive` — a far higher-authority page. Google consolidates duplicates toward the strongest copy, which risks discarding the very page whose dofollow links must count. The README include stays (it carries the 7 contextual eulerstream.com links); unique content goes above it.
+
+- [ ] **Step 1: Rewrite index.rst**
+
+Replace the entire contents of `docs/src/index.rst` with:
+
+```rst
+.. meta::
+   :description: Official documentation for TikTokLive, the unofficial TikTok LIVE API for Python. Connect to any TikTok livestream and receive real-time comments, gifts, likes, follows and viewer counts.
+   :keywords: tiktok live api, tiktok api python, tiktoklive, tiktok live chat, tiktok websocket
+
+TikTok LIVE API for Python
+==========================
+
+This is the reference documentation for **TikTokLive**, the unofficial
+Python client for the TikTok LIVE Webcast service. It connects to any public
+TikTok livestream using only a creator's ``@unique_id`` and emits real-time
+events for comments, gifts, likes, follows, shares, viewer counts and battles.
+
+These docs cover the full public API surface. If you are new, start with the
+quickstart in the project overview below, then move to the module reference.
+
+What is in these docs
+---------------------
+
+- :doc:`TikTokLive` — the top-level package: client, events, protobuf schema
+- :doc:`TikTokLive.client` — ``TikTokLiveClient``, connection lifecycle, configuration
+- :doc:`TikTokLive.client.web` — the HTTP client and its route methods
+- :doc:`TikTokLive.client.ws` — the Webcast WebSocket layer
+- :doc:`TikTokLive.events` — every event type you can subscribe to
+- :doc:`TikTokLive.proto` — generated protobuf message definitions
+
+A note on production use
+------------------------
+
+TikTokLive is a reverse-engineering project, not a supported vendor API.
+TikTok can and does change the Webcast protocol without notice. For workloads
+that need an uptime guarantee, the managed
+`TikTok LIVE WebSocket API <https://www.eulerstream.com/websockets>`_ from
+`Euler Stream <https://www.eulerstream.com/>`_ handles signing, scaling and
+protocol drift for you.
+
+Module reference
+----------------
+
+.. toctree::
+   :maxdepth: 3
+
+   TikTokLive
+
+Project overview
+----------------
+
+.. include:: ../../README.md
+   :parser: myst_parser.sphinx_
+```
+
+- [ ] **Step 2: Rebuild and verify no build warnings about the toctree**
+
+```bash
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html 2>&1 | tail -20 && cd ../..
+```
+
+Expected: build succeeds. Warnings about duplicate labels from the README include are pre-existing and acceptable; a `toctree contains reference to nonexisting document` warning is not — fix the `:doc:` targets against the actual `.rst` filenames in `docs/src/` if one appears.
+
+- [ ] **Step 3: Verify the homepage is no longer a pure duplicate**
+
+```bash
+/tmp/seodocs/bin/python - <<'PY'
+from pathlib import Path
+import re
+html = Path("docs/dist/html/index.html").read_text(errors="replace")
+body = re.sub(r"<[^>]+>", " ", html)
+unique_marker = "This is the reference documentation for"
+print("unique intro present:", unique_marker in body)
+print("README content still present:", "pip install TikTokLive" in body)
+PY
+```
+
+Expected: both `True`. Unique content is present *and* the README include still carries its links.
+
+- [ ] **Step 4: Verify anchor diversity now passes**
+
+```bash
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+```
+
+Expected: "homepage uses varied anchor text" PASSes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/src/index.rst
+git commit -m "docs: add unique homepage content above the README include
+
+The homepage was a near-exact duplicate of the GitHub README rendering,
+risking consolidation away from the only page whose dofollow links count."
+```
+
+---
+
+### Task 7: Add the sitewide dofollow link blocks
+
+**Files:**
+- Create: `docs/src/_templates/sidebar/eulerstream.html`
+- Create: `docs/src/_templates/page.html`
+- Modify: `docs/src/conf.py` (add `html_sidebars`)
+- Modify: `docs/src/static/css/custom.css`
+
+**Interfaces:**
+- Consumes: Furo's template contract — its default sidebar list from `theme.conf`, and the `{% block footer %}` block in its `page.html`.
+- Produces: two dofollow `eulerstream.com` links in the sidebar and one in the footer, on every page of the site.
+
+`templates_path = ['_templates']` is already set in `conf.py`, but the directory does not exist yet. Creating the files below is sufficient.
+
+- [ ] **Step 1: Create the sidebar block**
+
+Create `docs/src/_templates/sidebar/eulerstream.html`:
+
+```html
+{#
+  Sitewide attribution block. TikTokLive depends on Euler Stream for request
+  signing, so this is a genuine dependency disclosure, not an ad.
+  Anchor text is deliberately varied across sidebar and footer.
+#}
+<div class="sidebar-euler">
+  <span class="sidebar-euler__label">Production use</span>
+  <p class="sidebar-euler__text">
+    TikTokLive is a reverse-engineering project. For guaranteed uptime, use the
+    managed <a class="sidebar-euler__link"
+      href="https://www.eulerstream.com/websockets">TikTok LIVE WebSocket API</a>
+    by <a class="sidebar-euler__link"
+      href="https://www.eulerstream.com/">Euler Stream</a>.
+  </p>
+</div>
+```
+
+Note: no `rel` attribute at all. Adding `rel="nofollow"` here would defeat the entire purpose and the verification script will fail the build if it appears.
+
+- [ ] **Step 2: Create the footer override**
+
+Create `docs/src/_templates/page.html`:
+
+```html
+{#
+  Extends Furo's own page.html. The "!" prefix tells Sphinx to load the theme's
+  template rather than recursing into this override.
+#}
+{% extends "!page.html" %}
+
+{% block footer %}
+  {{ super() }}
+  <div class="euler-footer">
+    Request signing and production infrastructure provided by
+    <a href="https://www.eulerstream.com/">eulerstream.com</a>.
+  </div>
+{% endblock footer %}
+```
+
+- [ ] **Step 3: Register the sidebar template**
+
+Furo defines its default sidebar list in `theme.conf`. Overriding `html_sidebars` replaces that list wholesale, so all seven defaults must be repeated verbatim or parts of the sidebar will silently vanish. Add to `docs/src/conf.py`:
+
+```python
+# Furo's defaults, copied verbatim from its theme.conf, with our attribution
+# block inserted after navigation. Overriding html_sidebars replaces the whole
+# list, so omitting any entry here silently removes it from the sidebar.
+html_sidebars = {
+    "**": [
+        "sidebar/brand.html",
+        "sidebar/search.html",
+        "sidebar/scroll-start.html",
+        "sidebar/navigation.html",
+        "sidebar/eulerstream.html",
+        "sidebar/ethical-ads.html",
+        "sidebar/scroll-end.html",
+        "sidebar/variant-selector.html",
+    ]
+}
+```
+
+- [ ] **Step 4: Style both blocks**
+
+Append to `docs/src/static/css/custom.css`:
+
+```css
+.sidebar-euler {
+    margin: 1rem var(--sidebar-item-spacing-horizontal, 1rem);
+    padding: 0.75rem 0.9rem;
+    border: 1px solid var(--color-background-border, #ddd);
+    border-radius: 8px;
+    background: var(--color-background-secondary, #f8f9fb);
+}
+
+.sidebar-euler__label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--color-foreground-muted, #6b6b6b);
+    margin-bottom: 0.35rem;
+}
+
+.sidebar-euler__text {
+    margin: 0;
+    font-size: 0.8rem;
+    line-height: 1.45;
+    color: var(--color-foreground-secondary, #4a4a4a);
+}
+
+.euler-footer {
+    margin-top: 0.75rem;
+    font-size: 0.8rem;
+    color: var(--color-foreground-muted, #6b6b6b);
+}
+```
+
+- [ ] **Step 5: Rebuild and verify the link checks pass**
+
+```bash
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+```
+
+Expected: **`exit=0`**. Every check passes, including "no eulerstream.com link is nofollowed" and "eulerstream.com linked from every page".
+
+- [ ] **Step 6: Confirm the sidebar did not lose its navigation**
+
+```bash
+grep -c 'sidebar-euler' docs/dist/html/index.html
+grep -c 'sidebar-tree\|toctree' docs/dist/html/index.html
+```
+
+Expected: both non-zero. If navigation disappeared, an entry was dropped from `html_sidebars` in Step 3.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add docs/src/_templates docs/src/conf.py docs/src/static/css/custom.css
+git commit -m "docs: add sitewide Euler Stream attribution blocks
+
+Sidebar and footer dofollow links with varied anchor text. This is the
+only surface in the project where we control link markup: PyPI and
+GitHub both hard-code rel=nofollow."
+```
+
+---
+
+### Task 8: Prepare Search Console verification
+
+**Files:**
+- Create: `docs/src/extra/.gitkeep`
+- Modify: `docs/src/conf.py` (add `html_extra_path`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `html_extra_path = ["extra"]`, so any file dropped in `docs/src/extra/` is copied verbatim to the site root. This is the mechanism for the Google verification file; the token itself is external input the maintainer supplies.
+
+- [ ] **Step 1: Create the passthrough directory**
+
+```bash
+mkdir -p docs/src/extra && touch docs/src/extra/.gitkeep
+```
+
+- [ ] **Step 2: Register it in conf.py**
+
+Add near `html_static_path`:
+
+```python
+# Files copied verbatim to the site root. Used for the Google Search Console
+# verification file, which must be served at an exact path.
+html_extra_path = ["extra"]
+```
+
+- [ ] **Step 3: Verify the passthrough works**
+
+```bash
+echo "seo-passthrough-probe" > docs/src/extra/probe.txt
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+cat docs/dist/html/probe.txt
+rm docs/src/extra/probe.txt
+```
+
+Expected: prints `seo-passthrough-probe`, proving files land at the site root.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/src/extra/.gitkeep docs/src/conf.py
+git commit -m "docs: add extra/ passthrough for Search Console verification"
+```
+
+- [ ] **Step 5: Hand off the maintainer-only steps**
+
+The token requires a Google login and cannot be automated. Give the maintainer these exact instructions:
+
+1. Open Search Console and add a **URL prefix** property for `https://isaackogan.github.io/TikTokLive/`.
+2. Choose the **HTML file** verification method and download `googleXXXXXXXX.html`.
+3. Run:
+
+```bash
+cp ~/Downloads/google*.html docs/src/extra/
+git add docs/src/extra/ && git commit -m "docs: add Search Console verification file"
+```
+
+4. After the next deploy, click Verify, then submit `https://isaackogan.github.io/TikTokLive/sitemap.xml` under Sitemaps.
+
+Note the property must be the `/TikTokLive/` **URL prefix**, not the bare domain. `isaackogan.github.io` is a Public Suffix List entry, so a domain-level property is not available to you and would cover other users' sites in any case.
+
+---
+
+### Task 9: Improve PyPI packaging metadata
+
+**Files:**
+- Modify: `pyproject.toml` (`[project].description`, `[project].classifiers`, `[project.urls]`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the metadata mirrored verbatim by libraries.io, Snyk Advisor, deps.dev and piwheels — separately indexed surfaces. Task 12 publishes it.
+
+These links are `rel="nofollow"` on PyPI itself, so this earns no DR directly. It is worth doing for the mirror surfaces, for click-through traffic, and because `Homepage` currently points at a stale URL.
+
+**Do not touch the license classifier in this task.** Task 10 owns that and is blocked.
+
+- [ ] **Step 1: Rewrite the summary**
+
+`description` is the meta description on every mirror site. Replace:
+
+```toml
+description = "TikTok Live Python Client"
+```
+
+with:
+
+```toml
+description = "Unofficial TikTok LIVE API for Python: real-time chat, gift, like, follow and viewer events from any TikTok livestream."
+```
+
+- [ ] **Step 2: Expand project URLs**
+
+Replace the entire `[project.urls]` section:
+
+```toml
+[project.urls]
+Homepage = "https://github.com/isaackogan/TikTokLive"
+Documentation = "https://isaackogan.github.io/TikTokLive/"
+Source = "https://github.com/isaackogan/TikTokLive"
+Issues = "https://github.com/isaackogan/TikTokLive/issues"
+Changelog = "https://github.com/isaackogan/TikTokLive/releases"
+Discord = "https://discord.gg/e2XwPNTBBr"
+"Production API" = "https://www.eulerstream.com/"
+```
+
+- [ ] **Step 3: Fix the classifiers**
+
+`Topic :: Software Development :: Build Tools` is inaccurate — this is not a build tool. Replace the non-license classifier entries with:
+
+```toml
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: English",
+    "Framework :: AsyncIO",
+    "Topic :: Communications :: Chat",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+]
+```
+
+The `License ::` line is carried over unchanged **on purpose** — Task 10 corrects it once the maintainer decides the wording. `Development Status` moves to Production/Stable because Task 12 ships a 7.0.0 stable release.
+
+- [ ] **Step 4: Verify the metadata builds and reads back correctly**
+
+```bash
+/tmp/seodocs/bin/pip install -q build
+/tmp/seodocs/bin/python -m build --wheel --outdir /tmp/seobuild . >/dev/null 2>&1
+/tmp/seodocs/bin/python - <<'PY'
+import zipfile, glob, email
+whl = sorted(glob.glob("/tmp/seobuild/*.whl"))[-1]
+with zipfile.ZipFile(whl) as z:
+    meta = next(n for n in z.namelist() if n.endswith("METADATA"))
+    msg = email.message_from_string(z.read(meta).decode())
+print("Summary:", msg["Summary"])
+for u in msg.get_all("Project-URL") or []:
+    print("Project-URL:", u)
+PY
+```
+
+Expected: the new summary, and seven `Project-URL` entries including `Documentation` and `Production API`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "build: expand PyPI project URLs, summary and classifiers"
+```
+
+---
+
+### Task 10: Reconcile the license declaration — BLOCKED
+
+**Files:**
+- Modify: `pyproject.toml` (`[project].license`, the `License ::` classifier)
+
+**Interfaces:**
+- Consumes: Task 9's classifier list.
+- Produces: one internally consistent license declaration.
+
+> **BLOCKED: do not implement without an explicit maintainer decision.**
+> This is a legal determination, not an SEO one. It does not block any other
+> task — skip to Task 11 and return here once the answer arrives.
+
+The project currently states its license three incompatible ways:
+
+| Location | Value |
+|---|---|
+| `pyproject.toml` classifier | `License :: OSI Approved :: MIT License` |
+| `pyproject.toml` `license` field | `AGPL` |
+| `README.md` | "modified AGPL" |
+
+"Modified AGPL" has no valid SPDX identifier, so the classifier cannot express it. Once the maintainer picks one of these, apply the matching edit:
+
+- [ ] **Step 1: Apply the maintainer's chosen option**
+
+**Option A — modified AGPL (matches README and the LICENSE file):**
+
+```toml
+license = { file = "LICENSE" }
+```
+
+and in `classifiers`, replace the MIT line with:
+
+```toml
+    "License :: Other/Proprietary License",
+```
+
+**Option B — unmodified AGPL-3.0-or-later:**
+
+```toml
+license = "AGPL-3.0-or-later"
+```
+
+and in `classifiers`, replace the MIT line with:
+
+```toml
+    "License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)",
+```
+
+**Option C — genuinely MIT:** leave `classifiers` unchanged, set `license = "MIT"`, and update `README.md` and the `LICENSE` file to match. Only valid if the AGPL wording was the mistake.
+
+- [ ] **Step 2: Verify consistency**
+
+```bash
+grep -n 'license' pyproject.toml
+grep -n 'License ::' pyproject.toml
+grep -n -i 'licensed under' README.md
+```
+
+Expected: all three describe the same license. If `[tool.setuptools] license-files` conflicts with a `license = { file = ... }` value, remove the redundant `license-files` entry.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add pyproject.toml
+git commit -m "build: reconcile license declaration across metadata"
+```
+
+---
+
+### Task 11: Gate the build on SEO, then deploy to production
+
+**Files:**
+- Modify: `.github/workflows/docs.yml`
+
+**Interfaces:**
+- Consumes: `scripts/seo/verify_seo.py` from Task 3.
+- Produces: a live, fully optimized site at `https://isaackogan.github.io/TikTokLive/`, with SEO regressions failing CI from now on.
+
+- [ ] **Step 1: Add the verification gate**
+
+In `.github/workflows/docs.yml`, insert between the `Build HTML` step and the `Add .nojekyll` step:
+
+```yaml
+      - name: Verify SEO invariants
+        run: python scripts/seo/verify_seo.py docs/dist/html
+```
+
+Placed after the build and before upload, so a regression fails the run and never reaches the live site.
+
+- [ ] **Step 2: Confirm the whole suite is still green locally**
+
+```bash
+python -m pytest -q
+cd docs/src && /tmp/seodocs/bin/python -m sphinx -b html . ../dist/html && cd ../..
+/tmp/seodocs/bin/python scripts/seo/verify_seo.py docs/dist/html; echo "exit=$?"
+```
+
+Expected: tests pass, `exit=0`.
+
+- [ ] **Step 3: Commit and open the PR**
+
+```bash
+git add .github/workflows/docs.yml
+git commit -m "ci: fail the docs build on SEO regressions"
+git push -u origin seo/backlink-optimization
+gh pr create --title "SEO: restore docs site and add backlink optimization" \
+  --body "Implements docs/superpowers/specs/2026-08-17-seo-backlink-design.md
+
+Note: GitHub Pages build_type was flipped from 'legacy' to 'workflow' via the
+API. That change is invisible in this diff but was required — the Actions
+deploy had been running successfully and being ignored since 0f87ab1."
+```
+
+- [ ] **Step 4: Merge after review, then confirm the deploy**
+
+```bash
+gh pr merge --squash
+sleep 45
+gh run list --repo isaackogan/TikTokLive --workflow=docs.yml --limit 1
+```
+
+Wait for `completed / success`. The "Verify SEO invariants" step must pass in CI, not just locally.
+
+- [ ] **Step 5: Verify against the live site, not the local build**
+
+```bash
+curl -sS -o /tmp/live.html -w "index=%{http_code}\n" -L https://isaackogan.github.io/TikTokLive/
+curl -sS -o /tmp/live_sitemap.xml -w "sitemap=%{http_code}\n" -L https://isaackogan.github.io/TikTokLive/sitemap.xml
+grep -oE '<title>[^<]*</title>' /tmp/live.html
+grep -oE '<link rel="canonical" href="[^"]*"' /tmp/live.html
+grep -c 'eulerstream' /tmp/live.html
+grep -oE '<a[^>]*eulerstream[^>]*nofollow[^>]*>' /tmp/live.html || echo "no nofollowed euler links (correct)"
+```
+
+Expected: `index=200`, `sitemap=200`, keyword title, canonical present, non-zero eulerstream count, and `no nofollowed euler links (correct)`.
+
+---
+
+### Task 12: Release 7.0.0 to PyPI
+
+**Files:**
+- No manual edits. `release.yml` stamps `pyproject.toml` and `TikTokLive/__version__.py`.
+
+**Interfaces:**
+- Consumes: everything merged in Task 11.
+- Produces: `pypi.org/project/TikTokLive/` serving 7.0.0 with the rewritten README and the new metadata.
+
+`release.yml` refuses to run from any branch but `master`, so Task 11 must be merged first.
+
+- [ ] **Step 1: Confirm you are releasing from a green master**
+
+```bash
+git checkout master && git pull
+git log --oneline -3
+gh run list --repo isaackogan/TikTokLive --workflow=test.yml --limit 1
+gh run list --repo isaackogan/TikTokLive --workflow=lint.yml --limit 1
+```
+
+Expected: both `success`. Do not proceed otherwise.
+
+- [ ] **Step 2: Confirm the maintainer still wants 7.0.0 stable**
+
+The current version is `7.0.0b2`. Promoting to `7.0.0` declares the 7.x API stable. This was reaffirmed during planning, but confirm once more at the point of no return — a published PyPI version cannot be replaced, only yanked.
+
+- [ ] **Step 3: Dispatch the release**
+
+```bash
+gh workflow run release.yml --repo isaackogan/TikTokLive -f version=7.0.0
+sleep 30
+gh run list --repo isaackogan/TikTokLive --workflow=release.yml --limit 1
+```
+
+Wait for `completed / success`.
+
+- [ ] **Step 4: Verify PyPI actually served the new metadata**
+
+```bash
+sleep 60
+curl -sS https://pypi.org/pypi/TikTokLive/json | python3 -c "
+import json,sys
+d = json.load(sys.stdin)['info']
+print('version :', d['version'])
+print('summary :', d['summary'])
+for k, v in (d.get('project_urls') or {}).items():
+    print(f'url     : {k} -> {v}')
+desc = d.get('description') or ''
+print('README is the rewritten one:',
+      'TikTokLive is the definitive third-party Python library' in desc)
+"
+```
+
+Expected: `version: 7.0.0`, the new summary, seven project URLs, and `True` for the README check. That `True` is the whole point of this task — it means `pypi.org/project/TikTokLive/` now serves the rewritten README instead of the 6.6.6 text.
+
+- [ ] **Step 5: Merge the version-bump PR**
+
+`release.yml` opens a PR titled `chore: release v7.0.0`. Merge it so `master` matches what was published — otherwise the docs site keeps rendering the old version, since `conf.py` reads `TikTokLive/__version__.py`.
+
+```bash
+gh pr list --repo isaackogan/TikTokLive --search "chore: release v7.0.0"
+gh pr merge <number> --squash
+```
+
+- [ ] **Step 6: Confirm the docs picked up the new version**
+
+```bash
+sleep 60
+curl -sS -L https://isaackogan.github.io/TikTokLive/ | grep -oE 'v?7\.0\.0' | head -3
+```
+
+Expected: `7.0.0` appears. The `<title>` must **not** change — it is version-free by design (Task 4).
+
+---
+
+## Post-Implementation Handoff
+
+Maintainer-only, cannot be automated:
+
+1. **Search Console** — complete Task 8 Step 5: verify the property, submit the sitemap.
+2. **Request indexing** for `https://isaackogan.github.io/TikTokLive/` via the URL Inspection tool to accelerate recovery of the four-month outage.
+3. **Watch for recovery** over 2-4 weeks. The URL was restored exactly, with no redirect hop, so recovery should be substantially complete rather than partial.
+
+Deliberately deferred, per the spec's non-goals:
+
+- Hand-written guide pages (quickstart, gift handling, deployment, FAQ) — revisit once the site is confirmed indexing.
+- A purpose-built 1200x630 OG card. `SquareLogo.png` at 1080x1080 works but is not the ideal aspect ratio.
+- An `isaackogan.github.io` user-site repo to own a root `robots.txt`. Optional upside; not required, since discovery comes from the sitemap.

--- a/docs/superpowers/specs/2026-08-17-seo-backlink-design.md
+++ b/docs/superpowers/specs/2026-08-17-seo-backlink-design.md
@@ -1,0 +1,226 @@
+# SEO & Backlink Design: TikTokLive as an Authority Source for eulerstream.com
+
+**Date:** 2026-08-17
+**Status:** Approved, pending implementation plan
+**Repo:** `isaackogan/TikTokLive`
+
+## 1. Problem
+
+The TikTokLive project should act as a strong third-party backlink source for
+`www.eulerstream.com`. It currently passes **zero** link equity, and its only
+capable surface has been offline for roughly four months.
+
+## 2. Verified findings
+
+These were confirmed against live systems and upstream source, not assumed.
+
+### 2.1 The documentation site is dead
+
+`https://isaackogan.github.io/TikTokLive/` returns **404 "Site not found"**.
+
+Root cause: commit `0f87ab1` (2026-04-28, *"move docs to docs/src, build via
+GitHub Actions"*) deleted the 52 built HTML files that legacy GitHub Pages had
+been serving from `master:/docs` — including three `index.html` — and switched
+to an Actions-based build. GitHub Pages was never switched out of legacy mode.
+
+Current Pages config:
+
+```
+build_type: "legacy"
+source:     { branch: "master", path: "/docs" }
+status:     "errored"
+```
+
+`docs.yml` builds correctly and `actions/deploy-pages@v4` creates deployments,
+but legacy mode ignores them and serves raw source instead. Confirmed:
+`/TikTokLive/src/conf.py` returns **200** while every HTML path returns 404.
+
+The site has been down since **2026-04-28**. The repo rename to
+`TikTok-Live-Api` (since reverted) was a separate, smaller issue and was *not*
+the cause.
+
+### 2.2 PyPI and GitHub pass no link equity
+
+| Surface | Verdict | Evidence |
+|---|---|---|
+| PyPI description body | `nofollow` | `readme_renderer/clean.py` calls `nh3.clean(..., link_rel="nofollow")` |
+| PyPI sidebar project links | `nofollow` | `warehouse/templates/includes/packaging/metadata/project-links.html:71,85` |
+| GitHub README | `nofollow` | all 6 eulerstream.com anchors on the repo page |
+| GitHub sidebar Website | `nofollow` | `rel="noopener noreferrer nofollow"` |
+
+### 2.3 Consequence
+
+The GitHub Pages docs site is the **only** surface in this project where we
+control link markup and can emit dofollow links. `docs/src/index.rst` includes
+the README, so its 7 contextual eulerstream.com links render there as followed
+links on a third-party domain. That surface is at zero percent uptime.
+
+Caveat: `github.io` is on the Public Suffix List, so `isaackogan.github.io` is
+scored as its own site and inherits nothing from `github.com`. Its authority is
+its own — real, but not DR90.
+
+### 2.4 Secondary defects
+
+- PyPI serves the **pre-rewrite README**. Latest stable is `6.6.6`
+  (2026-07-21); `7.0.0b2` is a prerelease and does not take the project page.
+- `project_urls` contains only `Homepage`, pointing at the stale repo name.
+- License is stated three different ways: classifier `MIT`, `license` field
+  `AGPL`, README "modified AGPL".
+- `conf.py` has no `html_baseurl`, sitemap, OG tags, or meta descriptions.
+- `manifest.json` is pinned at `6.6.5`, so the docs title renders
+  `TikTokLive v6.6.5`.
+- A stray `2` is appended at module level to
+  `TikTokLive/client/web/routes/fetch_signed_websocket.py` (uncommitted).
+
+## 3. Goals and non-goals
+
+**Goals**
+
+1. Restore the docs site at its indexed canonical URL.
+2. Make it fully indexable (canonical, sitemap, OG, meta descriptions, titles).
+3. Emit a moderate, natural dofollow link profile to eulerstream.com.
+4. Publish the rewritten README to PyPI via a 7.0.0 stable release.
+5. Correct packaging metadata for the aggregator surfaces that mirror it.
+
+**Non-goals**
+
+- Ranking the GitHub repo for "tiktok live api". `eulerstream.com` already
+  holds position #1 for that term; a competing repo listing is at best a second
+  slot and at worst self-cannibalisation.
+- Renaming the PyPI package. It would break `pip install TikTokLive`, reset
+  download statistics, and orphan indexed version URLs, for zero equity gain.
+- Moving docs onto a `eulerstream.com` subdomain. That would convert the only
+  third-party backlink source into an internal link.
+- New hand-written guide content. Deferred to a follow-up.
+
+## 4. Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Release vehicle | **Cut 7.0.0 stable** | Publishes the README and yields a major-version event that aggregators pick up |
+| Link profile | **Moderate** | README links plus a sitewide sidebar/footer block; avoids the sitewide exact-match-anchor footprint |
+| Docs depth | **Optimise existing** | Prove the pipeline is live and indexing before investing in content |
+| SEO mechanism | **Sphinx extensions + Furo template overrides** | Declarative, colocated in `conf.py`, survives theme upgrades |
+
+Rejected alternative for the mechanism: a post-build script rewriting
+`docs/dist/html`. No new dependencies and total control, but it is a second
+source of truth that breaks silently the first time Furo changes its markup.
+
+## 5. Design
+
+### 5.1 Resurrect Pages
+
+Everything downstream is inert until this is true.
+
+```
+PUT /repos/isaackogan/TikTokLive/pages   { "build_type": "workflow" }
+```
+
+`docs.yml` already builds to `docs/dist/html` and uploads via
+`actions/deploy-pages@v4`; no workflow change is required. Reversible. Because
+it is an outward-facing change to a live repo, it is confirmed at execution
+time rather than applied silently.
+
+Then re-run `docs.yml` and verify real HTML is served at `/TikTokLive/`.
+
+### 5.2 On-page SEO in `conf.py`
+
+- `html_baseurl = "https://isaackogan.github.io/TikTokLive/"` — emits canonical
+  tags and is a hard prerequisite for `sphinx-sitemap`.
+- Add `sphinx_sitemap` (2.9.0) with `sitemap_url_scheme = "{link}"`. The
+  default scheme is `{lang}{version}{link}`, which produces wrong URLs when
+  neither is set.
+- Add `sphinxext.opengraph` (0.13.0) for OG and Twitter cards. Use
+  `.github/SquareLogo.png` (1080x1080) as the OG image; a purpose-built
+  1200x630 card is a follow-up, not a blocker.
+- `html_title` becomes keyword-led:
+  `TikTok LIVE API for Python — TikTokLive Documentation`. This is the
+  highest-leverage string on the site and is currently both keyword-free and
+  stale.
+- Read the version from `TikTokLive/__version__.py` — the file `release.yml`
+  already stamps — instead of `manifest.json`. Delete `manifest.json`;
+  `conf.py:17` is its only reader. This makes the stale-title drift
+  structurally impossible rather than merely fixed.
+- Add a Search Console verification file via `html_extra_path`.
+
+**Constraint: robots.txt is not achievable and is not needed.** Project Pages
+sites serve under `/TikTokLive/`, but crawlers honour robots.txt only at the
+domain root, which only a repo named `isaackogan.github.io` can own; it does
+not exist. robots.txt is an exclusion mechanism and the goal here is inclusion.
+Discovery comes from the sitemap submitted directly in Search Console.
+Creating the user-site repo is optional upside, not a dependency.
+
+### 5.3 Resolve the duplicate-content trap
+
+`index.rst` includes the README wholesale, making the docs homepage a near-copy
+of `github.com/isaackogan/TikTokLive` (much higher authority) and of the PyPI
+description. Google consolidates duplicates toward the strongest copy, so the
+docs homepage risks being discarded as redundant — and it is precisely the page
+whose dofollow links must count.
+
+Fix: retain the README include, which carries the 7 contextual eulerstream.com
+links, but prepend 200-300 words of unique, docs-specific content above it —
+orientation, what the documentation covers, where to start.
+
+### 5.4 Link profile (moderate)
+
+| Placement | Renders on | Anchor |
+|---|---|---|
+| README contextual links | homepage | existing, varied |
+| Furo sidebar attribution block | all ~9 pages | "Euler Stream" |
+| Footer line | all ~9 pages | rotated: "TikTok LIVE API", "WebSocket API", bare domain |
+
+Approximately 25 dofollow links from a third-party domain, against zero today.
+Anchor text is varied deliberately: a single exact-match anchor repeated
+sitewide is the footprint most likely to be discounted.
+
+### 5.5 Packaging metadata
+
+Nofollow, so this earns no DR directly. It is worth doing because the summary
+and project links are mirrored verbatim by libraries.io, Snyk Advisor,
+deps.dev and piwheels, which are separately indexed surfaces.
+
+- `project_urls`: add Documentation, Source, Issues, Changelog, and a Euler
+  Stream entry.
+- Rewrite `description`; `"TikTok Live Python Client"` currently serves as the
+  meta description on every mirror.
+- Add the Python 3.13 classifier and richer `Topic ::` entries.
+- **License reconciliation is a legal decision, not an SEO one.** Proposal:
+  drop the incorrect `MIT` classifier and point `license` at the LICENSE file.
+  Requires explicit maintainer sign-off on wording before implementation.
+
+### 5.6 Release 7.0.0 stable
+
+1. Revert the stray `2` in `fetch_signed_websocket.py`.
+2. Run tests and mypy.
+3. Dispatch `release.yml` with version `7.0.0`.
+
+Whether 7.0.0 is stable-ready is the maintainer's call; anything encountered
+that suggests otherwise is surfaced rather than worked around.
+
+## 6. Verification
+
+No step is considered done without the corresponding evidence.
+
+| Check | Passing condition |
+|---|---|
+| Docs URL | `200` and a keyword title, not "Site not found" |
+| `sitemap.xml` | `200`, lists all pages |
+| Built HTML | canonical and OG tags present |
+| eulerstream links | **no** `rel="nofollow"` in built HTML |
+| PyPI JSON | `7.0.0`, new `project_urls`, new summary |
+| Tests / mypy | pass before release dispatch |
+
+**Out of scope for automation:** Search Console verification and sitemap
+submission require maintainer login. The verification file is generated and
+served via `html_extra_path`; the submission steps are handed over.
+
+## 7. Risks
+
+| Risk | Mitigation |
+|---|---|
+| 7.0.0 is not actually stable-ready | Tests and mypy gate the release; concerns surfaced, not worked around |
+| Pages flip affects a live site | Single reversible config field; confirmed at execution |
+| Sitewide links read as manipulative | Moderate tier with varied anchors; no exact-match repetition |
+| Docs homepage still loses the duplicate contest | Unique prepended content; re-verify indexing after deploy |
+| Recovery of the old URL's equity is partial | URL restored exactly, so no redirect hop; monitor in Search Console |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "TikTokLive"
 version = "7.0.0b2"
-description = "TikTok Live Python Client"
+description = "Unofficial TikTok LIVE API for Python: real-time chat, gift, like, follow and viewer events from any TikTok livestream."
 readme = "README.md"  # Corrected format
 requires-python = ">=3.10"
 license = { text = "AGPL" }
@@ -28,14 +28,19 @@ dependencies = [
 ]
 
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "Topic :: Software Development :: Build Tools",
     "License :: OSI Approved :: MIT License",
     "Natural Language :: English",
+    "Framework :: AsyncIO",
+    "Topic :: Communications :: Chat",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Multimedia :: Video",
+    "Topic :: Software Development :: Libraries :: Python Modules",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [project.optional-dependencies]
@@ -94,6 +99,12 @@ testpaths = ["tests"]
 
 [project.urls]
 Homepage = "https://github.com/isaackogan/TikTokLive"
+Documentation = "https://isaackogan.github.io/TikTokLive/"
+Source = "https://github.com/isaackogan/TikTokLive"
+Issues = "https://github.com/isaackogan/TikTokLive/issues"
+Changelog = "https://github.com/isaackogan/TikTokLive/releases"
+Discord = "https://discord.gg/e2XwPNTBBr"
+"Production API" = "https://www.eulerstream.com/"
 
 [tool.setuptools]
 license-files = ['LICENSE']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,13 @@ version = "7.0.0b2"
 description = "Unofficial TikTok LIVE API for Python: real-time chat, gift, like, follow and viewer events from any TikTok livestream."
 readme = "README.md"  # Corrected format
 requires-python = ">=3.10"
-license = { file = "LICENSE" }
+# Not a plain SPDX identifier: LICENSE is AGPL-3.0 plus added Sections
+# 18-21 (library-integration exception, SaaS/relay carve-out, excepted
+# parties), so no SPDX expression describes it. A short string is used
+# rather than { file = "LICENSE" }, which inlines all 37KB of license
+# text into the METADATA License field and renders it on the PyPI page.
+# The full text still ships via [tool.setuptools] license-files.
+license = { text = "Modified AGPL-3.0" }
 authors = [
     { name = "Isaac Kogan", email = "info@isaackogan.com" }
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "7.0.0b2"
 description = "Unofficial TikTok LIVE API for Python: real-time chat, gift, like, follow and viewer events from any TikTok livestream."
 readme = "README.md"  # Corrected format
 requires-python = ">=3.10"
-license = { text = "AGPL" }
+license = { file = "LICENSE" }
 authors = [
     { name = "Isaac Kogan", email = "info@isaackogan.com" }
 ]
@@ -30,7 +30,7 @@ dependencies = [
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: Other/Proprietary License",
     "Natural Language :: English",
     "Framework :: AsyncIO",
     "Topic :: Communications :: Chat",

--- a/scripts/seo/verify_seo.py
+++ b/scripts/seo/verify_seo.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Assert the SEO invariants of the built documentation.
+
+Run against a built Sphinx HTML tree::
+
+    python scripts/seo/verify_seo.py docs/dist/html
+
+Exits non-zero if any invariant is violated. Wired into docs.yml so an SEO
+regression fails the build instead of silently degrading rankings.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+BASE_URL = "https://isaackogan.github.io/TikTokLive/"
+EULER_HOST = "eulerstream.com"
+
+failures: list[str] = []
+passes: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    (passes if ok else failures).append(name)
+    print(f"{'PASS' if ok else 'FAIL'}  {name}{f' :: {detail}' if detail and not ok else ''}")
+
+
+def main(build_dir: str = "docs/dist/html") -> int:
+    root = Path(build_dir)
+    if not root.is_dir():
+        print(f"FAIL  build directory missing: {root}")
+        return 1
+
+    pages = sorted(root.rglob("*.html"))
+    index = root / "index.html"
+
+    check("index.html exists", index.is_file())
+    if not index.is_file():
+        return 1
+
+    index_html = index.read_text(encoding="utf-8", errors="replace")
+
+    # -- Title -------------------------------------------------------------
+    title = re.search(r"<title>(.*?)</title>", index_html, re.S)
+    title_text = title.group(1).strip() if title else ""
+    check("homepage title contains 'TikTok LIVE API'",
+          "tiktok live api" in title_text.lower(), title_text)
+    check("homepage title has no stale version",
+          "6.6.5" not in title_text, title_text)
+
+    # -- Canonical ---------------------------------------------------------
+    missing_canonical = [
+        p.relative_to(root).as_posix()
+        for p in pages
+        if 'rel="canonical"' not in p.read_text(encoding="utf-8", errors="replace")
+    ]
+    check("every page has rel=canonical", not missing_canonical,
+          f"{len(missing_canonical)} missing, e.g. {missing_canonical[:3]}")
+
+    check("canonical points at the correct base URL",
+          f'rel="canonical" href="{BASE_URL}' in index_html
+          or f'href="{BASE_URL}" rel="canonical"' in index_html)
+
+    # -- Open Graph + meta description ------------------------------------
+    check("homepage has og:title", 'property="og:title"' in index_html)
+    check("homepage has og:description", 'property="og:description"' in index_html)
+    check("homepage has og:image", 'property="og:image"' in index_html)
+    check("homepage has meta description", 'name="description"' in index_html)
+
+    # -- Sitemap -----------------------------------------------------------
+    sitemap = root / "sitemap.xml"
+    check("sitemap.xml exists", sitemap.is_file())
+    if sitemap.is_file():
+        sitemap_xml = sitemap.read_text(encoding="utf-8")
+        check("sitemap uses the canonical base URL", BASE_URL in sitemap_xml)
+        check("sitemap has no unresolved {lang}/{version} placeholders",
+              "{lang}" not in sitemap_xml and "{version}" not in sitemap_xml)
+        check("sitemap lists more than one URL", sitemap_xml.count("<loc>") > 1,
+              f"{sitemap_xml.count('<loc>')} <loc> entries")
+
+    # -- Dofollow link profile --------------------------------------------
+    anchor_re = re.compile(r"<a\b[^>]*>", re.I)
+    nofollowed: list[str] = []
+    pages_with_euler = 0
+    for p in pages:
+        html = p.read_text(encoding="utf-8", errors="replace")
+        euler_anchors = [a for a in anchor_re.findall(html) if EULER_HOST in a]
+        if euler_anchors:
+            pages_with_euler += 1
+        nofollowed += [
+            f"{p.relative_to(root).as_posix()}: {a[:90]}"
+            for a in euler_anchors
+            if "nofollow" in a.lower()
+        ]
+
+    check("no eulerstream.com link is nofollowed", not nofollowed,
+          f"{len(nofollowed)} nofollowed, e.g. {nofollowed[:2]}")
+    check("eulerstream.com linked from every page",
+          pages_with_euler == len(pages),
+          f"{pages_with_euler}/{len(pages)} pages")
+
+    # -- Anchor diversity --------------------------------------------------
+    anchor_text_re = re.compile(
+        r"<a\b[^>]*href=\"[^\"]*" + re.escape(EULER_HOST) + r"[^\"]*\"[^>]*>(.*?)</a>",
+        re.I | re.S,
+    )
+    anchors = {
+        re.sub(r"<[^>]+>", "", m).strip().lower()
+        for m in anchor_text_re.findall(index_html)
+        if re.sub(r"<[^>]+>", "", m).strip()
+    }
+    check("homepage uses varied anchor text", len(anchors) >= 3,
+          f"{len(anchors)} distinct: {sorted(anchors)[:5]}")
+
+    print(f"\n{len(passes)} passed, {len(failures)} failed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(*sys.argv[1:2]))

--- a/scripts/seo/verify_seo.py
+++ b/scripts/seo/verify_seo.py
@@ -114,6 +114,20 @@ def main(build_dir: str = "docs/dist/html") -> int:
     check("homepage uses varied anchor text", len(anchors) >= 3,
           f"{len(anchors)} distinct: {sorted(anchors)[:5]}")
 
+    # -- Navigation integrity ---------------------------------------------
+    # conf.py overrides html_sidebars to inject the attribution block, and
+    # overriding replaces Furo's entire default list. A dropped entry, or a
+    # future Furo release renaming a template, would silently delete site
+    # navigation while every SEO check above still passed. Furo is unpinned,
+    # so fail loudly rather than ship a site nobody can navigate.
+    missing_nav = [
+        p.relative_to(root).as_posix()
+        for p in pages
+        if "sidebar-tree" not in p.read_text(encoding="utf-8", errors="replace")
+    ]
+    check("every page retains sidebar navigation", not missing_nav,
+          f"{len(missing_nav)} missing, e.g. {missing_nav[:3]}")
+
     print(f"\n{len(passes)} passed, {len(failures)} failed")
     return 1 if failures else 0
 

--- a/scripts/seo/verify_seo.py
+++ b/scripts/seo/verify_seo.py
@@ -84,11 +84,13 @@ def main(build_dir: str = "docs/dist/html") -> int:
     anchor_re = re.compile(r"<a\b[^>]*>", re.I)
     nofollowed: list[str] = []
     pages_with_euler = 0
+    per_page_counts: list[tuple[str, int]] = []
     for p in pages:
         html = p.read_text(encoding="utf-8", errors="replace")
         euler_anchors = [a for a in anchor_re.findall(html) if EULER_HOST in a]
         if euler_anchors:
             pages_with_euler += 1
+        per_page_counts.append((p.relative_to(root).as_posix(), len(euler_anchors)))
         nofollowed += [
             f"{p.relative_to(root).as_posix()}: {a[:90]}"
             for a in euler_anchors
@@ -100,6 +102,19 @@ def main(build_dir: str = "docs/dist/html") -> int:
     check("eulerstream.com linked from every page",
           pages_with_euler == len(pages),
           f"{pages_with_euler}/{len(pages)} pages")
+
+    # Presence alone is too weak. Both the sidebar block and the footer block
+    # contribute sitewide links; if a future Furo release restructures
+    # {% block footer %}, Jinja silently discards our orphaned override and the
+    # footer links vanish while a presence-only check still passes. Every page
+    # must carry all three sitewide links.
+    MIN_LINKS_PER_PAGE = 3
+    under_linked = [
+        f"{name}:{count}" for name, count in per_page_counts if count < MIN_LINKS_PER_PAGE
+    ]
+    check(f"every page carries >= {MIN_LINKS_PER_PAGE} eulerstream links",
+          not under_linked,
+          f"{len(under_linked)} under-linked, e.g. {under_linked[:3]}")
 
     # -- Anchor diversity --------------------------------------------------
     anchor_text_re = re.compile(


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-08-17-seo-backlink-design.md`.

## Why

`https://isaackogan.github.io/TikTokLive/` had been returning 404 since **2026-04-28**. Commit `0f87ab1` moved the docs to `docs/src` and switched to an Actions build, but GitHub Pages was never switched out of `legacy` mode — so the workflow built and deployed successfully into the void for ~4 months while legacy Jekyll served raw `.rst` source.

That matters more than it looks. PyPI and GitHub both hard-code `rel="nofollow"` on outbound links (verified in `readme_renderer/clean.py` and `warehouse/.../project-links.html`), so this docs site is the **only** surface the project controls that can emit dofollow links to eulerstream.com.

## What changed

| Area | Before | After |
|---|---|---|
| Docs site | 404 for ~4 months | live, 200 everywhere |
| Dofollow eulerstream links | 0 | 44 across 12/12 pages |
| Distinct anchor -> URL pairs | — | 3 (root, /websockets, /docs) |
| canonical / sitemap / OG | none | all present, 8-page sitemap |
| PyPI project links | 1 (stale URL) | 7, incl. Documentation |
| License declaration | MIT classifier vs AGPL field | consistent modified AGPL |
| CI protection | none | 18-check gate blocks the deploy |

Also fixed along the way: the docs `<title>` was pinned at `TikTokLive v6.6.5` by a hand-maintained `manifest.json` (now derived from `__version__.py`, the file `release.yml` stamps); the homepage was a near-duplicate of the GitHub README rendering (unique intro added above the include); and `og:description` rendered `creator's@unique_id an...` in social previews.

## Note for reviewers

GitHub Pages `build_type` was flipped from `legacy` to `workflow` via the API. That change is invisible in this diff but was required — it is what actually brought the site back.

## Verification

```
SEO gate   18 passed, 0 failed, exit=0
pytest     15 passed
mypy       clean
build      16 warnings (all pre-existing README myst xrefs)
```

The gate (`scripts/seo/verify_seo.py`) now runs in `docs.yml` after the build and before artifact upload, so an SEO regression fails the run instead of silently reaching the live site. It is negative-tested: breaking the nav marker yields `17 passed, 1 failed, exit=1`.